### PR TITLE
Annotations, Actions, and more

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,6 @@
 use pdf_writer::{
-    ActionType, AnnotationType, BorderType, Content, Name,
-    PdfWriter, Rect, Ref, Str, TextStr,
+    ActionType, AnnotationType, BorderType, Content, Name, PdfWriter, Rect, Ref, Str,
+    TextStr,
 };
 
 fn main() -> std::io::Result<()> {
@@ -31,13 +31,13 @@ fn main() -> std::io::Result<()> {
 
     // Set the size to A4 (measured in points) using `media_box` and set the
     // text object we'll write later as the page's contents.
-    //
+    page.media_box(Rect::new(0.0, 0.0, 595.0, 842.0));
+    page.parent(page_tree_id);
+    page.contents(text_id);
+
     // We also create the annotations list here that allows us to have things
     // like links or comments on the page.
-    let mut annots = page
-        .parent(page_tree_id)
-        .media_box(Rect::new(0.0, 0.0, 595.0, 842.0))
-        .annots();
+    let mut annots = page.annotations();
 
     // Write a new annotation.
     let mut annot = annots.add();
@@ -47,16 +47,13 @@ fn main() -> std::io::Result<()> {
         .subtype(AnnotationType::Link)
         .rect(Rect::new(215.0, 730.0, 251.0, 748.0))
         .contents(TextStr("Link to the Rust project web page"))
+        .color_rgb(0.0, 0.0, 1.0)
         .action()
         .action_type(ActionType::Uri)
         .uri(Str(b"https://www.rust-lang.org/"));
 
     // Set border and style for the link annotation.
-    annot
-        .color_rgb(0.0, 0.0, 1.0)
-        .border_style()
-        .width(3.0)
-        .style(BorderType::Underline);
+    annot.border_style().width(3.0).style(BorderType::Underline);
 
     // We have to drop all the writers that page depends on in order here
     // because otherwise it would be mutably borrowed until the end of the
@@ -66,7 +63,7 @@ fn main() -> std::io::Result<()> {
 
     // We also need to specify which resources the page needs, which in our case
     // is only a font that we name "F1" (the specific name doesn't matter).
-    page.contents(text_id).resources().fonts().pair(font_name, font_id);
+    page.resources().fonts().pair(font_name, font_id);
 
     drop(page);
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -37,29 +37,30 @@ fn main() -> std::io::Result<()> {
 
     // We also create the annotations list here that allows us to have things
     // like links or comments on the page.
-    let mut annots = page.annotations();
+    let mut annotations = page.annotations();
 
     // Write a new annotation.
-    let mut annot = annots.add();
+    let mut annotation = annotations.push();
 
     // Write the type, area, and action for this annotation.
-    annot
-        .subtype(AnnotationType::Link)
-        .rect(Rect::new(215.0, 730.0, 251.0, 748.0))
-        .contents(TextStr("Link to the Rust project web page"))
-        .color_rgb(0.0, 0.0, 1.0)
+    annotation.subtype(AnnotationType::Link);
+    annotation.rect(Rect::new(215.0, 730.0, 251.0, 748.0));
+    annotation.contents(TextStr("Link to the Rust project web page"));
+    annotation.color_rgb(0.0, 0.0, 1.0);
+
+    annotation
         .action()
         .action_type(ActionType::Uri)
         .uri(Str(b"https://www.rust-lang.org/"));
 
     // Set border and style for the link annotation.
-    annot.border_style().width(3.0).style(BorderType::Underline);
+    annotation.border_style().width(3.0).style(BorderType::Underline);
 
     // We have to drop all the writers that page depends on in order here
     // because otherwise it would be mutably borrowed until the end of the
     // block.
-    drop(annot);
-    drop(annots);
+    drop(annotation);
+    drop(annotations);
 
     // We also need to specify which resources the page needs, which in our case
     // is only a font that we name "F1" (the specific name doesn't matter).

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -42,12 +42,15 @@ fn main() -> std::io::Result<()> {
     // Write a new annotation.
     let mut annotation = annotations.push();
 
-    // Write the type, area, and action for this annotation.
+    // Write the type, area, alt-text, and color for this annotation.
     annotation.subtype(AnnotationType::Link);
     annotation.rect(Rect::new(215.0, 730.0, 251.0, 748.0));
     annotation.contents(TextStr("Link to the Rust project web page"));
     annotation.color_rgb(0.0, 0.0, 1.0);
 
+    // Write an action for the annotation, telling it where to link to. Actions
+    // can be associated with annotations, outline objects, and more and allow
+    // creating interactive PDFs (open links, play sounds...).
     annotation
         .action()
         .action_type(ActionType::Uri)

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+/// Writer for a _transition dictionary_.
+///
+/// This struct is created by [`Page::trans`].
+pub struct Transition<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> Transition<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        let mut dict = obj.dict();
+        dict.pair(Name(b"Type"), Name(b"Trans"));
+        Self { dict }
+    }
+
+    /// Write the `/S` attribute to set the transition style.
+    pub fn style(&mut self, kind: TransitionStyle) -> &mut Self {
+        self.pair(Name(b"S"), kind.to_name());
+        self
+    }
+
+    /// Write the `/D` attribute to set the transition duration.
+    pub fn duration(&mut self, seconds: f32) -> &mut Self {
+        self.pair(Name(b"D"), seconds);
+        self
+    }
+
+    /// Write the `/Dm` attribute to set the transition direction. Will be
+    /// horizontal if the argument is `false`.
+    pub fn dimension(&mut self, vertical: bool) -> &mut Self {
+        let name = if vertical { Name(b"V") } else { Name(b"H") };
+
+        self.pair(Name(b"Dm"), name);
+        self
+    }
+
+    /// Write the `/M` attribute to set the transition direction. Will be
+    /// inwards if the argument is `false`.
+    pub fn direction(&mut self, outward: bool) -> &mut Self {
+        let name = if outward { Name(b"O") } else { Name(b"I") };
+
+        self.pair(Name(b"M"), name);
+        self
+    }
+
+    /// Write the `/Di` attribute to set the transition angle.
+    pub fn angle(&mut self, angle: TransitionDirection) -> &mut Self {
+        if let Some(number) = angle.to_number() {
+            self.pair(Name(b"Di"), number);
+        } else {
+            self.pair(Name(b"Di"), angle.to_name().unwrap());
+        }
+
+        self
+    }
+
+    /// Write the `/SS` attribute to set the scale for the `Fly` transition.
+    /// (1.5+)
+    pub fn scale(&mut self, scale: f32) -> &mut Self {
+        self.pair(Name(b"SS"), scale);
+        self
+    }
+
+    /// Write the `/B` attribute for the `Fly` transition. (1.5+)
+    pub fn opaque(&mut self, opaque: f32) -> &mut Self {
+        self.pair(Name(b"F"), opaque);
+        self
+    }
+}
+
+deref!('a, Transition<'a> => Dict<'a>, dict);
+
+/// The kind of transition.
+pub enum TransitionStyle {
+    /// Split the slide down the middle.
+    Split,
+    /// Multiple lines roll up the slide.
+    Blinds,
+    /// The new slide is revealed in a growing box.
+    Box,
+    /// Single line that sweeps across the slide.
+    Wipe,
+    /// Slide dissolves gradually.
+    Dissolve,
+    /// Like dissolve, but starts on one side.
+    Glitter,
+    /// No effect.
+    R,
+    /// Changes are flown in. (1.5+)
+    Fly,
+    /// Old page slides out, new page slides in. (1.5+)
+    Push,
+    /// New page slides in to cover the old one. (1.5+)
+    Cover,
+    /// Old page slides out to uncover the new one. (1.5+)
+    Uncover,
+    /// A cross-fade. (1.5+)
+    Fade,
+}
+
+impl TransitionStyle {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::Split => Name(b"Split"),
+            Self::Blinds => Name(b"Blinds"),
+            Self::Box => Name(b"Box"),
+            Self::Wipe => Name(b"Wipe"),
+            Self::Dissolve => Name(b"Dissolve"),
+            Self::Glitter => Name(b"Glitter"),
+            Self::R => Name(b"R"),
+            Self::Fly => Name(b"Fly"),
+            Self::Push => Name(b"Push"),
+            Self::Cover => Name(b"Cover"),
+            Self::Uncover => Name(b"Uncover"),
+            Self::Fade => Name(b"Fade"),
+        }
+    }
+}
+
+/// The angle at which the transition plays.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[allow(missing_docs)]
+pub enum TransitionDirection {
+    LeftToRight,
+    BottomToTop,
+    RightToLeft,
+    TopToBottom,
+    TopLeftToBottomRight,
+    /// No direction in the `Fly` style.
+    None,
+}
+
+impl TransitionDirection {
+    fn to_number(&self) -> Option<i32> {
+        match self {
+            Self::LeftToRight => Some(0),
+            Self::BottomToTop => Some(90),
+            Self::RightToLeft => Some(180),
+            Self::TopToBottom => Some(270),
+            Self::TopLeftToBottomRight => Some(315),
+            Self::None => None,
+        }
+    }
+
+    fn to_name(&self) -> Option<Name<'static>> {
+        match self {
+            Self::None => Some(Name(b"None")),
+            _ => None,
+        }
+    }
+}
+
+/// Writer for an _action dictionary_.
+///
+/// This struct is created by [`Annotation::action`].
+pub struct Action<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> Action<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        let mut dict = obj.dict();
+        dict.pair(Name(b"Type"), Name(b"Action"));
+        Self { dict }
+    }
+
+    /// Write the `/S` attribute to set the action type.
+    pub fn action_type(&mut self, kind: ActionType) -> &mut Self {
+        self.pair(Name(b"S"), kind.to_name());
+        self
+    }
+
+    /// Start writing the `/D` attribute to set the destination of this
+    /// GoTo-type action.
+    pub fn dest_direct(&mut self, page: Ref) -> Destination<'_> {
+        Destination::start(self.key(Name(b"D")), page)
+    }
+
+    /// Write the `/D` attribute to set the destination of this GoTo-type action
+    /// to a named destination.
+    pub fn dest_name(&mut self, name: Name) -> &mut Self {
+        self.pair(Name(b"D"), name);
+        self
+    }
+
+    /// Start writing the `/F` attribute, setting which file to go to or which
+    /// application to launch.
+    pub fn file(&mut self) -> FileSpec<'_> {
+        FileSpec::new(self.key(Name(b"F")))
+    }
+
+    /// Write the `/NewWindow` attribute to set whether this remote GoTo action
+    /// should open the referenced destination in another window.
+    pub fn new_window(&mut self, new: bool) -> &mut Self {
+        self.pair(Name(b"NewWindow"), new);
+        self
+    }
+
+    /// Write the `/URI` attribute to set where this link action goes.
+    pub fn uri(&mut self, uri: Str) -> &mut Self {
+        self.pair(Name(b"URI"), uri);
+        self
+    }
+
+    /// Write the `/IsMap` attribute to set if the click position of the user's
+    /// cursor inside the link rectangle should be appended to the referenced
+    /// URI as a query parameter.
+    pub fn is_map(&mut self, map: bool) -> &mut Self {
+        self.pair(Name(b"IsMap"), map);
+        self
+    }
+}
+
+deref!('a, Action<'a> => Dict<'a>, dict);
+
+/// What kind of action to perform.
+pub enum ActionType {
+    /// Go to a destination in the document.
+    GoTo,
+    /// Go to a destination in another document.
+    RemoteGoTo,
+    /// Launch an application.
+    Launch,
+    /// Open a URI.
+    Uri,
+}
+
+impl ActionType {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::GoTo => Name(b"GoTo"),
+            Self::RemoteGoTo => Name(b"GoToR"),
+            Self::Launch => Name(b"Launch"),
+            Self::Uri => Name(b"Uri"),
+        }
+    }
+}

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -232,7 +232,7 @@ impl ActionType {
             Self::GoTo => Name(b"GoTo"),
             Self::RemoteGoTo => Name(b"GoToR"),
             Self::Launch => Name(b"Launch"),
-            Self::Uri => Name(b"Uri"),
+            Self::Uri => Name(b"URI"),
         }
     }
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Writer for a _transition dictionary_.
 ///
-/// This struct is created by [`Page::trans`].
+/// This struct is created by [`Page::transition`].
 pub struct Transition<'a> {
     dict: Dict<'a>,
 }
@@ -30,7 +30,6 @@ impl<'a> Transition<'a> {
     /// horizontal if the argument is `false`.
     pub fn dimension(&mut self, vertical: bool) -> &mut Self {
         let name = if vertical { Name(b"V") } else { Name(b"H") };
-
         self.pair(Name(b"Dm"), name);
         self
     }
@@ -39,7 +38,6 @@ impl<'a> Transition<'a> {
     /// inwards if the argument is `false`.
     pub fn direction(&mut self, outward: bool) -> &mut Self {
         let name = if outward { Name(b"O") } else { Name(b"I") };
-
         self.pair(Name(b"M"), name);
         self
     }
@@ -67,6 +65,7 @@ impl<'a> Transition<'a> {
 deref!('a, Transition<'a> => Dict<'a>, dict);
 
 /// The kind of transition.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum TransitionStyle {
     /// Split the slide down the middle.
     Split,
@@ -203,6 +202,7 @@ impl<'a> Action<'a> {
 deref!('a, Action<'a> => Dict<'a>, dict);
 
 /// What kind of action to perform.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ActionType {
     /// Go to a destination in the document.
     GoTo,

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -45,13 +45,8 @@ impl<'a> Transition<'a> {
     }
 
     /// Write the `/Di` attribute to set the transition angle.
-    pub fn angle(&mut self, angle: TransitionDirection) -> &mut Self {
-        if let Some(number) = angle.to_number() {
-            self.pair(Name(b"Di"), number);
-        } else {
-            self.pair(Name(b"Di"), angle.to_name().unwrap());
-        }
-
+    pub fn angle(&mut self, angle: TransitionAngle) -> &mut Self {
+        angle.write_to_obj(self.key(Name(b"Di")));
         self
     }
 
@@ -121,7 +116,7 @@ impl TransitionStyle {
 /// The angle at which the transition plays.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
-pub enum TransitionDirection {
+pub enum TransitionAngle {
     LeftToRight,
     BottomToTop,
     RightToLeft,
@@ -131,22 +126,15 @@ pub enum TransitionDirection {
     None,
 }
 
-impl TransitionDirection {
-    fn to_number(&self) -> Option<i32> {
+impl TransitionAngle {
+    fn write_to_obj(&self, obj: Obj<'_>) {
         match self {
-            Self::LeftToRight => Some(0),
-            Self::BottomToTop => Some(90),
-            Self::RightToLeft => Some(180),
-            Self::TopToBottom => Some(270),
-            Self::TopLeftToBottomRight => Some(315),
-            Self::None => None,
-        }
-    }
-
-    fn to_name(&self) -> Option<Name<'static>> {
-        match self {
-            Self::None => Some(Name(b"None")),
-            _ => None,
+            Self::LeftToRight => obj.primitive(0),
+            Self::BottomToTop => obj.primitive(90),
+            Self::RightToLeft => obj.primitive(180),
+            Self::TopToBottom => obj.primitive(270),
+            Self::TopLeftToBottomRight => obj.primitive(315),
+            Self::None => obj.primitive(Name(b"None")),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ or whether you write all required fields for an object. Refer to the
 [page]: writers::Page
 [image stream]: writers::ImageStream
 [`filter()`]: Stream::filter
-[hello world example]: https://github.com/typst/pdf-writer/tree/main/examples/hello.rs^
+[hello world example]: https://github.com/typst/pdf-writer/tree/main/examples/hello.rs
 [PDF specification]: https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf
 */
 
@@ -99,13 +99,14 @@ pub mod writers {
     use super::*;
     pub use content::{ImageStream, Path, Text};
     pub use font::{CidFont, CmapStream, FontDescriptor, Type0Font, Type1Font, Widths};
-    pub use structure::{Catalog, Page, Pages, Resources};
+    pub use structure::{Catalog, Page, Pages, Resources, ViewerPreferences};
 }
 
 pub use content::{ColorSpace, Content, LineCapStyle};
 pub use font::{CidFontType, FontFlags, SystemInfo, UnicodeCmap};
 pub use object::*;
 pub use stream::*;
+pub use structure::{Direction, PageLayout, PageMode};
 
 use std::fmt::{self, Debug, Formatter};
 use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ pub use interactive::{ActionType, TransitionDirection, TransitionStyle};
 pub use object::*;
 pub use stream::*;
 pub use structure::{
-    AnnotationFlags, AnnotationName, AnnotationType, Direction, HighlightEffect,
-    OutlineItemFlags, PageLayout, PageMode,
+    AnnotationFlags, AnnotationName, AnnotationType, BorderType, Direction,
+    HighlightEffect, OutlineItemFlags, PageLayout, PageMode,
 };
 
 use std::fmt::{self, Debug, Formatter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,14 +99,20 @@ pub mod writers {
     use super::*;
     pub use content::{ImageStream, Path, Text};
     pub use font::{CidFont, CmapStream, FontDescriptor, Type0Font, Type1Font, Widths};
-    pub use structure::{Catalog, Page, Pages, Resources, ViewerPreferences};
+    pub use structure::{
+        Action, Annotation, Annotations, Catalog, Destination, Destinations, Page, Pages,
+        Resources, Transition, ViewerPreferences,
+    };
 }
 
 pub use content::{ColorSpace, Content, LineCapStyle};
 pub use font::{CidFontType, FontFlags, SystemInfo, UnicodeCmap};
 pub use object::*;
 pub use stream::*;
-pub use structure::{Direction, PageLayout, PageMode};
+pub use structure::{
+    ActionType, AnnotationFlags, AnnotationType, Direction, HighlightEffect, PageLayout,
+    PageMode, TransitionDirection, TransitionStyle,
+};
 
 use std::fmt::{self, Debug, Formatter};
 use std::io::Write;
@@ -278,6 +284,11 @@ impl PdfWriter {
     /// Start writing a font descriptor.
     pub fn font_descriptor(&mut self, id: Ref) -> FontDescriptor<'_> {
         FontDescriptor::start(self.indirect(id))
+    }
+
+    /// Start writing a named destination dictionary.
+    pub fn destinations(&mut self, id: Ref) -> Destinations<'_> {
+        Destinations::start(self.indirect(id))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ pub mod writers {
     pub use font::{CidFont, CmapStream, FontDescriptor, Type0Font, Type1Font, Widths};
     pub use interactive::{Action, Transition};
     pub use structure::{
-        Annotation, Annotations, Catalog, Destination, Destinations, FileSpec, Outline,
-        OutlineItem, Page, Pages, Resources, ViewerPreferences,
+        Annotation, Annotations, BorderStyle, Catalog, Destination, Destinations,
+        FileSpec, Outline, OutlineItem, Page, Pages, Resources, ViewerPreferences,
     };
 }
 
@@ -113,7 +113,7 @@ pub use interactive::{ActionType, TransitionAngle, TransitionStyle};
 pub use object::*;
 pub use stream::*;
 pub use structure::{
-    AnnotationFlags, AnnotationName, AnnotationType, BorderType, Direction,
+    AnnotationFlags, AnnotationIcon, AnnotationType, BorderType, Direction,
     HighlightEffect, OutlineItemFlags, PageLayout, PageMode,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ mod macros;
 mod buf;
 mod content;
 mod font;
+mod interactive;
 mod object;
 mod stream;
 mod structure;
@@ -99,19 +100,21 @@ pub mod writers {
     use super::*;
     pub use content::{ImageStream, Path, Text};
     pub use font::{CidFont, CmapStream, FontDescriptor, Type0Font, Type1Font, Widths};
+    pub use interactive::{Action, Transition};
     pub use structure::{
-        Action, Annotation, Annotations, Catalog, Destination, Destinations, Page, Pages,
-        Resources, Transition, ViewerPreferences,
+        Annotation, Annotations, Catalog, Destination, Destinations, FileSpec, Outline,
+        OutlineItem, Page, Pages, Resources, ViewerPreferences,
     };
 }
 
 pub use content::{ColorSpace, Content, LineCapStyle};
 pub use font::{CidFontType, FontFlags, SystemInfo, UnicodeCmap};
+pub use interactive::{ActionType, TransitionDirection, TransitionStyle};
 pub use object::*;
 pub use stream::*;
 pub use structure::{
-    ActionType, AnnotationFlags, AnnotationType, Direction, HighlightEffect, PageLayout,
-    PageMode, TransitionDirection, TransitionStyle,
+    AnnotationFlags, AnnotationName, AnnotationType, Direction, HighlightEffect,
+    OutlineItemFlags, PageLayout, PageMode,
 };
 
 use std::fmt::{self, Debug, Formatter};
@@ -289,6 +292,16 @@ impl PdfWriter {
     /// Start writing a named destination dictionary.
     pub fn destinations(&mut self, id: Ref) -> Destinations<'_> {
         Destinations::start(self.indirect(id))
+    }
+
+    /// Start writing an outline.
+    pub fn outline(&mut self, id: Ref) -> Outline<'_> {
+        Outline::start(self.indirect(id))
+    }
+
+    /// Start writing an outline item.
+    pub fn outline_item(&mut self, id: Ref) -> OutlineItem<'_> {
+        OutlineItem::start(self.indirect(id))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub mod writers {
 
 pub use content::{ColorSpace, Content, LineCapStyle};
 pub use font::{CidFontType, FontFlags, SystemInfo, UnicodeCmap};
-pub use interactive::{ActionType, TransitionDirection, TransitionStyle};
+pub use interactive::{ActionType, TransitionAngle, TransitionStyle};
 pub use object::*;
 pub use stream::*;
 pub use structure::{

--- a/src/object.rs
+++ b/src/object.rs
@@ -65,16 +65,11 @@ pub struct TextStr<'a>(pub &'a str);
 
 impl Primitive for TextStr<'_> {
     fn write(self, buf: &mut Vec<u8>) {
-        let iter = std::iter::once(254).chain(std::iter::once(255));
-        let bytes: Vec<_> = iter
-            .chain(
-                self.0
-                    .encode_utf16()
-                    .flat_map(|x| std::array::IntoIter::new(x.to_be_bytes())),
-            )
-            .collect();
-
-        Str(&bytes).write(buf)
+        let mut bytes = vec![254, 255];
+        for v in self.0.encode_utf16() {
+            bytes.extend(v.to_be_bytes());
+        }
+        Str(&bytes).write(buf);
     }
 }
 
@@ -251,7 +246,7 @@ impl Date {
         self
     }
 
-    /// Add the from UTC in minutes. This will have the same sign as set in
+    /// Add the offset from UTC in minutes. This will have the same sign as set in
     /// [`Self::utc_offset_hour`]. It will be clamped within the range 0-59.
     pub fn utc_offset_minute(&mut self, minute: u8) -> &mut Self {
         self.utc_offset_minute = Some(minute.min(59));
@@ -296,7 +291,7 @@ impl Primitive for Date {
                 None
             });
 
-        Str(&s.bytes().collect::<Vec<_>>()).write(buf)
+        Str(s.as_bytes())).write(buf);
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -56,6 +56,26 @@ impl Primitive for Str<'_> {
     }
 }
 
+/// A UTF-16BE-encoded text string object.
+///
+/// This is written as `(BOM <bytes>)`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TextStr<'a>(pub &'a str);
+
+impl Primitive for TextStr<'_> {
+    fn write(self, buf: &mut Vec<u8>) {
+        buf.push(b'(');
+        buf.push(254);
+        buf.push(255);
+        buf.extend(
+            self.0
+                .encode_utf16()
+                .flat_map(|x| std::array::IntoIter::new(x.to_be_bytes())),
+        );
+        buf.push(b')');
+    }
+}
+
 /// A name object.
 ///
 /// Written as `/Thing`.

--- a/src/object.rs
+++ b/src/object.rs
@@ -278,7 +278,7 @@ impl Primitive for Date {
                 None
             });
 
-        TextStr(&s).write(buf)
+        Str(&s.bytes().collect::<Vec<_>>()).write(buf)
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -168,7 +168,7 @@ impl Primitive for Rect {
 
 /// A date, represented as a text string.
 ///
-/// A field is only respected, if all superior fields are supplied. For example,
+/// A field is only respected if all superior fields are supplied. For example,
 /// to set the minute, the hour, day, etc. have to be set. Similarly, in order
 /// for the time zone information to be written, all time information (including
 /// seconds) must be written. `utc_offset_minute` is optional if supplying time

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -329,8 +329,9 @@ impl PageMode {
     }
 }
 
-/// Predominant reading order of text. Used to aid the viewer with the spacial
-/// ordering in which to display pages.
+/// Predominant reading order of text.
+///
+/// Used to aid the viewer with the spacial ordering in which to display pages.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Direction {
     /// Left-to-right.
@@ -403,7 +404,7 @@ impl<'a> Annotation<'a> {
         self
     }
 
-    /// Write the `/NM` attribute. This uniquely identified the anotation on the
+    /// Write the `/NM` attribute. This uniquely identifies the anotation on the
     /// page. (1.3+)
     pub fn name(&mut self, text: TextStr) -> &mut Self {
         self.pair(Name(b"NM"), text);
@@ -461,7 +462,7 @@ impl<'a> Annotation<'a> {
         self
     }
 
-    /// Write the `/C` attribute using a RGB color. This sets the annotations
+    /// Write the `/C` attribute using an RGB color. This sets the annotations
     /// background color and its popup title bar color. (1.1+)
     pub fn color_rgb(&mut self, r: f32, g: f32, b: f32) -> &mut Self {
         self.key(Name(b"C")).array().typed().items([r, g, b]);
@@ -509,7 +510,7 @@ impl<'a> Annotation<'a> {
         BorderStyle::new(self.key(Name(b"BS")))
     }
 
-    /// Write the `/QuadPoints` attribute.
+    /// Write the `/QuadPoints` attribute, specifying the region in which the link should be activated. (1.6+)
     pub fn quad_points(
         &mut self,
         x1: f32,
@@ -599,9 +600,9 @@ impl AnnotationType {
     }
 }
 
-/// A name that sets the icon for the annotation.
+/// Possible icons for an annotation.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum AnnotationName {
+pub enum AnnotationIcon {
     /// Speech bubble. For use with text annotations.
     Comment,
     /// For use with text annotations.
@@ -717,22 +718,22 @@ impl<'a> FileSpec<'a> {
     }
 
     /// Write the `/FS` attribute to set the file system this entry relates to.
-    /// If you set the `system` argument to `Name(b"URL")`, this becomes a URL
-    /// Specification.
+    /// If you set the `system` argument to `Name(b"URL")`, this becomes an URL
+    /// specification.
     pub fn file_system(&mut self, system: Name) -> &mut Self {
         self.pair(Name(b"FS"), system);
         self
     }
 
     /// Write the `/F` attribute to set the file path. Directories are indicated
-    /// by `/`, independant of the platform.
+    /// by `/`, independent of the platform.
     pub fn file(&mut self, path: Str) -> &mut Self {
         self.pair(Name(b"F"), path);
         self
     }
 
     /// Write the `/UF` attribute to set a Unicode-compatible path. Directories
-    /// are indicated by `/`, independant of the platform. (1.7+)
+    /// are indicated by `/`, independent of the platform. (1.7+)
     pub fn unic_file(&mut self, path: TextStr) -> &mut Self {
         self.pair(Name(b"UF"), path);
         self
@@ -816,7 +817,9 @@ impl BorderType {
     }
 }
 
-/// Writer for the _destination array_.
+/// Writer for a _destination array_.
+///
+/// This struct is created by [`Destinations::push`].
 pub struct Destination<'a> {
     array: Array<'a>,
 }
@@ -953,7 +956,7 @@ impl<'a> Outline<'a> {
 
 deref!('a, Outline<'a> => Dict<'a, IndirectGuard>, dict);
 
-/// Writer for an _outline dictionary_.
+/// Writer for an _outline item dictionary_.
 ///
 /// This struct is created by [`PdfWriter::outline_item`].
 pub struct OutlineItem<'a> {
@@ -1030,7 +1033,7 @@ impl<'a> OutlineItem<'a> {
         self
     }
 
-    /// Write the `/C` attribute using a RGB color. This sets the color in which
+    /// Write the `/C` attribute using an RGB color. This sets the color in which
     /// the outline item's title should be rendered. (1.4+)
     pub fn color(&mut self, r: f32, g: f32, b: f32) -> &mut Self {
         self.key(Name(b"C")).array().typed().items([r, g, b]);

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -19,9 +19,97 @@ impl<'a> Catalog<'a> {
         self.pair(Name(b"Pages"), id);
         self
     }
+
+    /// Write the `/PageLayout` attribute to determine how the viewer will
+    /// display the document's pages.
+    pub fn page_layout(&mut self, layout: PageLayout) -> &mut Self {
+        self.pair(Name(b"PageLayout"), layout.to_name());
+        self
+    }
+
+    /// Write the `/PageMode` attribute to set which chrome elements the viewer
+    /// should show.
+    pub fn page_mode(&mut self, mode: PageMode) -> &mut Self {
+        self.pair(Name(b"PageMode"), mode.to_name());
+        self
+    }
+
+    /// Start writing the `/ViewerPreferences` dictionary. Requires PDF 1.2 or
+    /// later.
+    pub fn viewer_preferences(&mut self) -> ViewerPreferences<'_> {
+        ViewerPreferences::new(self.key(Name(b"ViewerPreferences")))
+    }
 }
 
 deref!('a, Catalog<'a> => Dict<'a, IndirectGuard>, dict);
+
+/// Writer for a _viewer preference dictionary_.
+///
+/// This struct is created by [`Catalog::viewer_preferences`].
+pub struct ViewerPreferences<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> ViewerPreferences<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        Self { dict: obj.dict() }
+    }
+
+    /// Write the `/HideToolbar` attribute to set whether the viewer should hide
+    /// its toolbars while the document is open.
+    pub fn hide_toolbar(&mut self, hide: bool) -> &mut Self {
+        self.pair(Name(b"HideToolbar"), hide);
+        self
+    }
+
+    /// Write the `/HideMenubar` attribute to set whether the viewer should hide
+    /// its menu bar while the document is open.
+    pub fn hide_menubar(&mut self, hide: bool) -> &mut Self {
+        self.pair(Name(b"HideMenubar"), hide);
+        self
+    }
+
+    /// Write the `/FitWindow` attribute to set whether the viewer should resize
+    /// its window to the size of the first page.
+    pub fn fit_window(&mut self, hide: bool) -> &mut Self {
+        self.pair(Name(b"FitWindow"), hide);
+        self
+    }
+
+    /// Write the `/CenterWindow` attribute to set whether the viewer should
+    /// center its window on the screen.
+    pub fn center_window(&mut self, hide: bool) -> &mut Self {
+        self.pair(Name(b"CenterWindow"), hide);
+        self
+    }
+
+    /// Write the `/NonFullScreenPageMode` attribute to set which chrome
+    /// elements the viewer should show for a document which requests full
+    /// screen rendering in its catalog when it is not shown in full screen
+    /// mode.
+    ///
+    /// The function will panic if `mode` is set to [`PageMode::FullScreen`]
+    /// because the specification does not allow this enum variant here.
+    pub fn non_full_screen_page_mode(&mut self, mode: PageMode) -> &mut Self {
+        if mode == PageMode::FullScreen {
+            panic!(
+                "requesting full screen view for `/NonFullScreenPageMode` is disallowed by the specification"
+            );
+        }
+
+        self.pair(Name(b"NonFullScreenPageMode"), mode.to_name());
+        self
+    }
+
+    /// Write the `/Direction` attribute to aid the viewer in how to lay out the
+    /// pages visually. Requires PDF 1.3 or later.
+    pub fn direction(&mut self, dir: Direction) -> &mut Self {
+        self.pair(Name(b"Direction"), dir.to_name());
+        self
+    }
+}
+
+deref!('a, ViewerPreferences<'a> => Dict<'a>, dict);
 
 /// Writer for a _page tree_.
 ///
@@ -84,9 +172,36 @@ impl<'a> Page<'a> {
         self
     }
 
-    /// Write the `/MediaBox` attribute.
+    /// Write the `/MediaBox` attribute. This is the size of the physical medium
+    /// the page gets printed onto.
     pub fn media_box(&mut self, rect: Rect) -> &mut Self {
         self.pair(Name(b"MediaBox"), rect);
+        self
+    }
+
+    /// Write the `/CropBox` attribute.
+    pub fn crop_box(&mut self, rect: Rect) -> &mut Self {
+        self.pair(Name(b"CropBox"), rect);
+        self
+    }
+
+    /// Write the `/BleedBox` attribute. Requires PDF 1.3 or later.
+    pub fn bleed_box(&mut self, rect: Rect) -> &mut Self {
+        self.pair(Name(b"BleedBox"), rect);
+        self
+    }
+
+    /// Write the `/TrimBox` attribute. This is the size of the produced
+    /// document after trimming is applied. Requires PDF 1.3 or later.
+    pub fn trim_box(&mut self, rect: Rect) -> &mut Self {
+        self.pair(Name(b"TrimBox"), rect);
+        self
+    }
+
+    /// Write the `/ArtBox` attribute. This is the area that another program
+    /// importing this file should use. Requires PDF 1.3 or later.
+    pub fn art_box(&mut self, rect: Rect) -> &mut Self {
+        self.pair(Name(b"ArtBox"), rect);
         self
     }
 
@@ -99,6 +214,26 @@ impl<'a> Page<'a> {
     pub fn contents(&mut self, id: Ref) -> &mut Self {
         self.pair(Name(b"Contents"), id);
         self
+    }
+
+    /// Write the `/Dur` attribute. This is the amount of seconds the page
+    /// should be displayed before advancing to the next one. Requires PDF 1.1
+    /// or later.
+    pub fn dur(&mut self, seconds: f32) -> &mut Self {
+        self.pair(Name(b"Dur"), seconds);
+        self
+    }
+
+    /// Start writing the `/Trans` dictionary. This sets a transition effect for
+    /// advancing to the next page. Requires PDF 1.1 or later.
+    pub fn trans(&mut self) -> Transition<'_> {
+        todo!();
+        Transition::new(self.key(Name(b"Trans")))
+    }
+
+    /// Start writing the `/Annots` (annotations) array.
+    pub fn annots(&mut self) -> Annotations<'_> {
+        Annotations::start(self.key(Name(b"Annots")))
     }
 }
 
@@ -128,3 +263,401 @@ impl<'a> Resources<'a> {
 }
 
 deref!('a, Resources<'a> => Dict<'a>, dict);
+
+/// How the viewer should lay out the pages in the document.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum PageLayout {
+    /// Only a single page at a time.
+    SinglePage,
+    /// A single, continously scrolling column of pages.
+    OneColumn,
+    /// Two continously scrolling columns of pages, laid out with odd-numbered
+    /// pages on the left.
+    TwoColumnLeft,
+    /// Two continously scrolling columns of pages, laid out with odd-numbered
+    /// pages on the right (like in a left-bound book).
+    TwoColumnRight,
+    /// Only two pages are visible at a time, laid out with odd-numbered pages
+    /// on the left. Requires PDF 1.5 or later.
+    TwoPageLeft,
+    /// Only two pages are visible at a time, laid out with odd-numbered pages
+    /// on the right (like in a left-bound book). Requires PDF 1.5 or later.
+    TwoPageRight,
+}
+
+impl PageLayout {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::SinglePage => Name(b"SinglePage"),
+            Self::OneColumn => Name(b"OneColumn"),
+            Self::TwoColumnLeft => Name(b"TwoColumnLeft"),
+            Self::TwoColumnRight => Name(b"TwoColumnRight"),
+            Self::TwoPageLeft => Name(b"TwoPageLeft"),
+            Self::TwoPageRight => Name(b"TwoPageRight"),
+        }
+    }
+}
+
+/// Elements of the viewer chrome that should be visible when opening the
+/// document.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum PageMode {
+    /// Neither the document outline panel nor a panel with page preview images
+    /// are visible.
+    UseNone,
+    /// The document outline panel is visible.
+    UseOutlines,
+    /// A panel with page preview images is visible.
+    UseThumbs,
+    /// Show the document page in full screen mode, with no chrome.
+    FullScreen,
+}
+
+impl PageMode {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::UseNone => Name(b"UseNone"),
+            Self::UseOutlines => Name(b"UseOutlines"),
+            Self::UseThumbs => Name(b"UseThumbs"),
+            Self::FullScreen => Name(b"FullScreen"),
+        }
+    }
+}
+
+/// Predominant reading order of text. Used to aid the viewer with the spacial
+/// ordering in which to display pages.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Direction {
+    /// Left-to-right.
+    L2R,
+    /// Right-to-left as well as vertical writing systems.
+    R2L,
+}
+
+impl Direction {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::L2R => Name(b"L2R"),
+            Self::R2L => Name(b"R2L"),
+        }
+    }
+}
+
+/// Writer for a _transition dictionary_.
+///
+/// This struct is created by [`Page::trans`].
+pub struct Transition<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> Transition<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        Self { dict: obj.dict() }
+    }
+}
+
+deref!('a, Transition<'a> => Dict<'a>, dict);
+
+/// Writer for the _annotations array_ in a [`Page`].
+///
+/// This struct is created by [`Page::annots`].
+pub struct Annotations<'a> {
+    array: Array<'a>,
+}
+
+impl<'a> Annotations<'a> {
+    pub(crate) fn start(obj: Obj<'a>) -> Self {
+        Self { array: obj.array() }
+    }
+
+    /// Start writing a new annotation dictionary.
+    pub fn add(&mut self) -> Annotation<'_> {
+        Annotation::new(self.obj())
+    }
+}
+
+deref!('a, Annotations<'a> => Array<'a>, array);
+
+/// Writer for an _annotation dictionary_.
+///
+/// This struct is created by [`Annotations::add`].
+pub struct Annotation<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> Annotation<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        let mut dict = obj.dict();
+        dict.pair(Name(b"Type"), Name(b"Annot"));
+        Self { dict }
+    }
+
+    /// Write the `/Subtype` attribute to tell the viewer the type of this
+    /// particular annotation.
+    pub fn subtype(&mut self, kind: AnnotationType) -> &mut Self {
+        self.pair(Name(b"Subtype"), kind.to_name());
+        self
+    }
+
+    /// Write the `/Rect` attribute. This is the location and dimensions of the
+    /// annotation on the page.
+    pub fn rect(&mut self, rect: Rect) -> &mut Self {
+        self.pair(Name(b"Rect"), rect);
+        self
+    }
+
+    /// Write the `/Contents` attribute. This is the content or alt-text,
+    /// depending on the [`AnnotationType`].
+    pub fn contents(&mut self, text: Str) -> &mut Self {
+        self.pair(Name(b"Contents"), text);
+        self
+    }
+
+    /// Write the `/F` attribute.
+    pub fn flags(&mut self, flags: AnnotationFlags) -> &mut Self {
+        self.pair(Name(b"F"), flags.to_integer());
+        self
+    }
+
+    /// Write the `/C` attribute forcing a transparent color. This sets the
+    /// annotations background color and its popup title bar color. Requires PDF
+    /// 1.1 or later.
+    pub fn color_transparent(&mut self) -> &mut Self {
+        self.key(Name(b"C")).array().typed::<f32>();
+        self
+    }
+
+    /// Write the `/C` attribute using a grayscale color. This sets the
+    /// annotations background color and its popup title bar color. Requires PDF
+    /// 1.1 or later.
+    pub fn color_gray(&mut self, gray: f32) -> &mut Self {
+        self.key(Name(b"C")).array().typed::<f32>().item(gray);
+        self
+    }
+
+    /// Write the `/C` attribute using a RGB color. This sets the annotations
+    /// background color and its popup title bar color. Requires PDF 1.1 or
+    /// later.
+    pub fn color_rgb(&mut self, r: f32, g: f32, b: f32) -> &mut Self {
+        let mut array = self.key(Name(b"C")).array().typed::<f32>();
+        array.item(r);
+        array.item(g);
+        array.item(b);
+        drop(array);
+        self
+    }
+
+    /// Write the `/C` attribute using a CMYK color. This sets the annotations
+    /// background color and its popup title bar color. Requires PDF 1.1 or
+    /// later.
+    pub fn color_cmyk(&mut self, c: f32, m: f32, y: f32, k: f32) -> &mut Self {
+        let mut array = self.key(Name(b"C")).array().typed::<f32>();
+        array.item(c);
+        array.item(m);
+        array.item(y);
+        array.item(k);
+        drop(array);
+        self
+    }
+
+    /// Start writing the `/A` dictionary. Only permissible for the subtype
+    /// `Link`.
+    pub fn action(&mut self) -> Action<'_> {
+        Action::new(self.key(Name(b"A")))
+    }
+
+    /// Write the `/H` attribute to set what effect is used to convey that the
+    /// user is pressing a link annotation. Only permissible for the subtype
+    /// `Link`. Requires PDF 1.2 or later.
+    pub fn highlight(&mut self, effect: HighlightEffect) -> &mut Self {
+        self.pair(Name(b"H"), effect.to_name());
+        self
+    }
+}
+
+deref!('a, Annotation<'a> => Dict<'a>, dict);
+
+/// Kind of the annotation to produce.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum AnnotationType {
+    /// Inline text.
+    Text,
+    /// A link.
+    Link,
+    /// Text coming up in a popup. Requires PDF 1.3 or later.
+    FreeText,
+    /// A line. Requires PDF 1.3 or later.
+    Line,
+    /// A square. Requires PDF 1.3 or later.
+    Square,
+    /// A circle. Requires PDF 1.3 or later.
+    Circle,
+    /// Highlighting the text on the page. Requires PDF 1.3 or later.
+    Highlight,
+    /// Underline the text on the page. Requires PDF 1.3 or later.
+    Underline,
+    /// Squiggly underline of the text on the page. Requires PDF 1.4 or later.
+    Squiggly,
+    /// Strike out the text on the page. Requires PDF 1.3 or later.
+    StrikeOut,
+}
+
+impl AnnotationType {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::Text => Name(b"Text"),
+            Self::Link => Name(b"Link"),
+            Self::FreeText => Name(b"FreeText"),
+            Self::Line => Name(b"Line"),
+            Self::Square => Name(b"Square"),
+            Self::Circle => Name(b"Circle"),
+            Self::Highlight => Name(b"Highlight"),
+            Self::Underline => Name(b"Underline"),
+            Self::Squiggly => Name(b"Squiggly"),
+            Self::StrikeOut => Name(b"StrikeOut"),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Hash)]
+pub struct AnnotationFlags {
+    /// This will hide the annotation if the viewer does not recognize its
+    /// subtype. Otherwise, it will be rendered as specified in its apprearance
+    /// stream.
+    pub invisible: bool,
+    /// This hides the annotation from view and disallows interaction. Requires
+    /// PDF 1.2 or later.
+    pub hidden: bool,
+    /// Print the annotation. If not set, it will be always hidden on print.
+    /// Requires PDF 1.2 or later.
+    pub print: bool,
+    /// Do not zoom the annotation appearance if the document is zoomed in.
+    /// Requires PDF 1.3 or later.
+    pub no_zoom: bool,
+    /// Do not rotate the annotation appearance if the document is zoomed in.
+    /// Requires PDF 1.3 or later.
+    pub no_rotate: bool,
+    /// Do not view the annotation on screen. It may still show on print.
+    /// Requires PDF 1.3 or later.
+    pub no_view: bool,
+    /// Do not allow interactions. Requires PDF 1.3 or later.
+    pub read_only: bool,
+    /// Do not allow the user to delete or reposition the annotation. Contents
+    /// may still be changed. Requires PDF 1.4 or later.
+    pub locked: bool,
+    /// Invert the interpretation of the `no_view` flag for certain events.
+    /// Requires PDF 1.5 or later.
+    pub toggle_no_view: bool,
+    /// Do not allow content changes. Requires PDF 1.7 or later.
+    pub locked_contents: bool,
+}
+
+impl AnnotationFlags {
+    fn to_integer(self) -> i32 {
+        let mut res = 0;
+
+        if self.invisible {
+            res |= 0x1;
+        }
+        if self.hidden {
+            res |= 0x01;
+        }
+        if self.print {
+            res |= 0x001;
+        }
+        if self.no_zoom {
+            res |= 0x0001;
+        }
+        if self.no_rotate {
+            res |= 0x00001;
+        }
+        if self.no_view {
+            res |= 0x000001;
+        }
+        if self.read_only {
+            res |= 0x0000001;
+        }
+        if self.locked {
+            res |= 0x00000001;
+        }
+        if self.toggle_no_view {
+            res |= 0x000000001;
+        }
+        if self.locked_contents {
+            res |= 0x0000000001;
+        }
+
+        res
+    }
+}
+
+/// Highlighting effect.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum HighlightEffect {
+    /// No effect.
+    None,
+    /// Invert the colors inside of the annotation rect.
+    Invert,
+    /// Invert the colors on the annotation border.
+    Outline,
+    /// Make the annotation rect's area appear depressed.
+    Push,
+}
+
+impl HighlightEffect {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::None => Name(b"N"),
+            Self::Invert => Name(b"I"),
+            Self::Outline => Name(b"O"),
+            Self::Push => Name(b"P"),
+        }
+    }
+}
+
+/// Writer for an _action dictionary_.
+///
+/// This struct is created by [`Annotation::action`].
+pub struct Action<'a> {
+    dict: Dict<'a>,
+}
+
+impl<'a> Action<'a> {
+    pub(crate) fn new(obj: Obj<'a>) -> Self {
+        let mut dict = obj.dict();
+        dict.pair(Name(b"Type"), Name(b"Action"));
+        Self { dict }
+    }
+
+    /// Write the `/S` attribute to set the action type.
+    pub fn action_type(&mut self, kind: ActionType) -> &mut Self {
+        self.pair(Name(b"S"), kind.to_name());
+        self
+    }
+}
+
+deref!('a, Action<'a> => Dict<'a>, dict);
+
+pub enum ActionType {
+    // Go to a destination in the document.
+    GoTo,
+    // Launch an application.
+    Launch,
+    // Begin reading an article thread.
+    Thread,
+    // Open a URI.
+    Uri,
+}
+
+impl ActionType {
+    fn to_name(self) -> Name<'static> {
+        match self {
+            Self::GoTo => Name(b"GoTo"),
+            Self::Launch => Name(b"Launch"),
+            Self::Thread => Name(b"Thread"),
+            Self::Uri => Name(b"Uri"),
+        }
+    }
+}
+
+// TODO: 7.11.3, 12.6.4.2, 12.6.4.5-7, 12.5.2 Border, 12.5.4, 12.4.4.1, 12.3.2.2-3, and maybe 12.3.3

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -183,13 +183,16 @@ impl<'a> Page<'a> {
         self
     }
 
-    /// Write the `/CropBox` attribute.
+    /// Write the `/CropBox` attribute. This is the size of the area within
+    /// which content is visible.
     pub fn crop_box(&mut self, rect: Rect) -> &mut Self {
         self.pair(Name(b"CropBox"), rect);
         self
     }
 
-    /// Write the `/BleedBox` attribute. (1.3+)
+    /// Write the `/BleedBox` attribute. This is the size of the area within
+    /// which content is visible in a print production environment. Most
+    /// production-aiding marks should be outside of this box. (1.3+)
     pub fn bleed_box(&mut self, rect: Rect) -> &mut Self {
         self.pair(Name(b"BleedBox"), rect);
         self
@@ -222,19 +225,19 @@ impl<'a> Page<'a> {
 
     /// Write the `/Dur` attribute. This is the amount of seconds the page
     /// should be displayed before advancing to the next one. (1.1+)
-    pub fn dur(&mut self, seconds: f32) -> &mut Self {
+    pub fn duration(&mut self, seconds: f32) -> &mut Self {
         self.pair(Name(b"Dur"), seconds);
         self
     }
 
     /// Start writing the `/Trans` dictionary. This sets a transition effect for
     /// advancing to the next page. (1.1+)
-    pub fn trans(&mut self) -> Transition<'_> {
+    pub fn transition(&mut self) -> Transition<'_> {
         Transition::new(self.key(Name(b"Trans")))
     }
 
     /// Start writing the `/Annots` (annotations) array.
-    pub fn annots(&mut self) -> Annotations<'_> {
+    pub fn annotations(&mut self) -> Annotations<'_> {
         Annotations::start(self.key(Name(b"Annots")))
     }
 }


### PR DESCRIPTION
_it's spec time, baby_

This PR includes annotations (insert links and tell your co-authors why exactly their work is shite), actions (make your PDF do things that it clearly should not be able to do), more stuff on the document catalogue (setting RTL as the document direction and more), transitions (who needs PowerPoint anyways) and an example to boost.

It introduces two new data types: `Date`s and `TextStr` (UTF16 strings).