### PR TITLE
Fix typos

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -35,7 +35,7 @@ impl<'a> Annotation<'a> {
         self
     }
 
-    /// Write the `/NM` attribute. This uniquely identifies the anotation on the
+    /// Write the `/NM` attribute. This uniquely identifies the annotation on the
     /// page. PDF 1.3+.
     pub fn name(&mut self, text: TextStr) -> &mut Self {
         self.pair(Name(b"NM"), text);
@@ -276,7 +276,7 @@ bitflags::bitflags! {
     /// Bitflags describing various characteristics of annotations.
     pub struct AnnotationFlags: u32 {
         /// This will hide the annotation if the viewer does not recognize its
-        /// subtype. Otherwise, it will be rendered as specified in its apprearance
+        /// subtype. Otherwise, it will be rendered as specified in its appearance
         /// stream.
         const INVISIBLE = 1 << 0;
         /// This hides the annotation from view and disallows interaction. PDF 1.2+.
@@ -445,7 +445,7 @@ impl<'a> BorderStyle<'a> {
     }
 
     /// Write the `/D` attribute to set the repeating lengths of dashes and gaps
-    /// inbetween.
+    /// in between.
     pub fn dashes(&mut self, dash_pattern: impl IntoIterator<Item = f32>) -> &mut Self {
         self.insert(Name(b"D")).array().items(dash_pattern);
         self

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -297,14 +297,14 @@ impl LayoutAttributes<'_> {
     }
 
     /// Write the `/Width` attribute for table row groups and illustrative
-    /// elements. No instrinsic height will be assumed if left empty.
+    /// elements. No intrinsic height will be assumed if left empty.
     pub fn width(&mut self, width: f32) -> &mut Self {
         self.dict.pair(Name(b"Width"), width);
         self
     }
 
     /// Write the `/Height` attribute for table row groups and illustrative
-    /// elements. No instrinsic height will be assumed if left empty.
+    /// elements. No intrinsic height will be assumed if left empty.
     pub fn height(&mut self, height: f32) -> &mut Self {
         self.dict.pair(Name(b"Height"), height);
         self

--- a/src/content.rs
+++ b/src/content.rs
@@ -547,7 +547,7 @@ impl Content {
         self
     }
 
-    /// `T*`: Move to the start of the next line, determing the vertical offset
+    /// `T*`: Move to the start of the next line, determining the vertical offset
     /// through the text state's leading parameter.
     #[inline]
     pub fn next_line_using_leading(&mut self) -> &mut Self {
@@ -629,7 +629,7 @@ impl<'a> PositionedItems<'a> {
         Self { array: obj.array() }
     }
 
-    /// Show a continous string without adjustments.
+    /// Show a continuous string without adjustments.
     ///
     /// The encoding of the text depends on the font.
     #[inline]
@@ -1119,14 +1119,14 @@ impl ArtifactAttachment {
 
 /// Compatibility.
 impl Content {
-    /// `BX`: Begin a compatability section.
+    /// `BX`: Begin a compatibility section.
     #[inline]
     pub fn begin_compat(&mut self) -> &mut Self {
         self.op("BX");
         self
     }
 
-    /// `EX`: End a compatability section.
+    /// `EX`: End a compatibility section.
     #[inline]
     pub fn end_compat(&mut self) -> &mut Self {
         self.op("EX");
@@ -1227,7 +1227,7 @@ impl<'a> Resources<'a> {
     /// Start writing the `/Properties` attribute.
     ///
     /// This allows to write property lists with indirect objects for
-    /// marked-content sequences. These propeties can be used by property lists
+    /// marked-content sequences. These properties can be used by property lists
     /// using the [`MarkContent::properties_named`] method. PDF 1.2+.
     pub fn properties(&mut self) -> TypedDict<'_, PropertyList> {
         self.insert(Name(b"Properties")).dict().typed()
@@ -1238,7 +1238,7 @@ deref!('a, Resources<'a> => Dict<'a>, dict);
 
 /// What procedure sets to send to a PostScript printer or other output device.
 ///
-/// This enumeration provides compatibilty for printing PDFs of versions 1.3 and
+/// This enumeration provides compatibility for printing PDFs of versions 1.3 and
 /// below.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ProcSet {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -136,12 +136,12 @@ deref!('a, Catalog<'a> => Dict<'a>, dict);
 pub enum PageLayout {
     /// Only a single page at a time.
     SinglePage,
-    /// A single, continously scrolling column of pages.
+    /// A single, continuously scrolling column of pages.
     OneColumn,
-    /// Two continously scrolling columns of pages, laid out with odd-numbered
+    /// Two continuously scrolling columns of pages, laid out with odd-numbered
     /// pages on the left.
     TwoColumnLeft,
-    /// Two continously scrolling columns of pages, laid out with odd-numbered
+    /// Two continuously scrolling columns of pages, laid out with odd-numbered
     /// pages on the right (like in a left-bound book).
     TwoColumnRight,
     /// Only two pages are visible at a time, laid out with odd-numbered pages
@@ -820,7 +820,7 @@ deref!('a, MarkInfo<'a> => Dict<'a>, dict);
 
 /// Predominant reading order of text.
 ///
-/// Used to aid the viewer with the spacial ordering in which to display pages.
+/// Used to aid the viewer with the special ordering in which to display pages.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Direction {
     /// Left-to-right.
@@ -1180,7 +1180,7 @@ impl<'a> Page<'a> {
     }
 
     /// Write the `/Tabs` attribute. This specifies the order in which the
-    /// annotations should be focussed by hitting tab. PDF 1.5+.
+    /// annotations should be focused by hitting tab. PDF 1.5+.
     pub fn tab_order(&mut self, order: TabOrder) -> &mut Self {
         self.pair(Name(b"Tabs"), order.to_name());
         self

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -205,7 +205,7 @@ impl<'a> FormXObject<'a> {
     }
 
     /// Start writing the `/Resources` dictionary to specify the resources used
-    /// by the XObject. This makes it independant of the parent content stream
+    /// by the XObject. This makes it independent of the parent content stream
     /// it is eventually invoked in. PDF 1.2+.
     pub fn resources(&mut self) -> Resources<'_> {
         self.insert(Name(b"Resources")).start()
@@ -300,7 +300,7 @@ impl<'a> Group<'a> {
     /// group.
     ///
     /// Within a knockout group, the group children are all composited
-    /// seperately against the backdrop instead of on top of each other.
+    /// separately against the backdrop instead of on top of each other.
     pub fn knockout(&mut self, knockout: bool) -> &mut Self {
         self.pair(Name(b"K"), knockout);
         self


### PR DESCRIPTION
Found via `codespell -L crate,flate,fith`