### PR TITLE
Feature: Trigger events (PDF 1.7 Section 12.6.3)

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+/// Writer for an _action dictionary_.
+///
+/// This struct is created by [`Annotation::action`].
+pub struct Action<'a> {
+    dict: Dict<'a>,
+}
+
+writer!(Action: |obj| {
+    let mut dict = obj.dict();
+    dict.pair(Name(b"Type"), Name(b"Action"));
+    Self { dict }
+});
+
+impl<'a> Action<'a> {
+    /// Write the `/S` attribute to set the action type.
+    pub fn action_type(&mut self, kind: ActionType) -> &mut Self {
+        self.pair(Name(b"S"), kind.to_name());
+        self
+    }
+
+    /// Start writing the `/D` attribute to set the destination of this
+    /// GoTo-type action.
+    pub fn destination(&mut self) -> Destination<'_> {
+        self.insert(Name(b"D")).start()
+    }
+
+    /// Write the `/D` attribute to set the destination of this GoTo-type action
+    /// to a named destination.
+    pub fn destination_named(&mut self, name: Name) -> &mut Self {
+        self.pair(Name(b"D"), name);
+        self
+    }
+
+    /// Start writing the `/F` attribute, setting which file to go to or which
+    /// application to launch.
+    pub fn file_spec(&mut self) -> FileSpec<'_> {
+        self.insert(Name(b"F")).start()
+    }
+
+    /// Write the `/NewWindow` attribute to set whether this remote GoTo action
+    /// should open the referenced destination in another window.
+    pub fn new_window(&mut self, new: bool) -> &mut Self {
+        self.pair(Name(b"NewWindow"), new);
+        self
+    }
+
+    /// Write the `/URI` attribute to set where this link action goes.
+    pub fn uri(&mut self, uri: Str) -> &mut Self {
+        self.pair(Name(b"URI"), uri);
+        self
+    }
+
+    /// Write the `/IsMap` attribute to set if the click position of the user's
+    /// cursor inside the link rectangle should be appended to the referenced
+    /// URI as a query parameter.
+    pub fn is_map(&mut self, map: bool) -> &mut Self {
+        self.pair(Name(b"IsMap"), map);
+        self
+    }
+}
+
+deref!('a, Action<'a> => Dict<'a>, dict);
+
+/// What kind of action to perform when clicking a link annotation.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum ActionType {
+    /// Go to a destination in the document.
+    GoTo,
+    /// Go to a destination in another document.
+    RemoteGoTo,
+    /// Launch an application.
+    Launch,
+    /// Open a URI.
+    Uri,
+}
+
+impl ActionType {
+    pub(crate) fn to_name(self) -> Name<'static> {
+        match self {
+            Self::GoTo => Name(b"GoTo"),
+            Self::RemoteGoTo => Name(b"GoToR"),
+            Self::Launch => Name(b"Launch"),
+            Self::Uri => Name(b"URI"),
+        }
+    }
+}

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -65,16 +65,25 @@ impl<'a> Action<'a> {
         self
     }
 
-    /// Write the `/JS` attribute to set the script of this action. Only
-    /// permissible for JavaScript actions.
-    pub fn js(&mut self, script: TextStr) -> &mut Self {
+    /// Write the `/JS` attribute to set the script of this action as a text
+    /// string. Only permissible for JavaScript actions.
+    pub fn js_string(&mut self, script: TextStr) -> &mut Self {
+        self.pair(Name(b"JS"), script);
+        self
+    }
+
+    /// Write the `/JS` attribute to set the script of this action as a text
+    /// stream. The indirect reference shall point to a stream containing valid
+    /// ECMAScript. The stream must have `PdfDocEncoding` or be in Unicode,
+    /// starting with `U+FEFF`. Only permissible for JavaScript actions.
+    pub fn js_stream(&mut self, script: Ref) -> &mut Self {
         self.pair(Name(b"JS"), script);
         self
     }
 
     /// Start writing the `/Fields` array to set the fields which are
     /// [include/exclude](ActionFlags::INCLUDE_EXCLUDE) when submitting a form,
-    /// resetting a form or loading an FDF file.
+    /// resetting a form, or loading an FDF file.
     pub fn fields(&mut self) -> Fields<'_> {
         self.insert(Name(b"Fields")).start()
     }
@@ -132,6 +141,10 @@ pub enum ActionType {
     /// Import form field values from a file. PDF 1.2+.
     ImportData,
     /// Execute a JavaScript action. PDF 1.2+.
+    ///
+    /// See Adobe's
+    /// [JavaScript for Acrobat API Reference](https://opensource.adobe.com/dc-acrobat-sdk-docs/acrobatsdk/pdfs/acrobatsdk_jsapiref.pdf)
+    /// and ISO 21757.
     JavaScript,
 }
 
@@ -282,14 +295,14 @@ impl<'a> AdditionalActions<'a> {
     /// Start writing the `/Fo` dictionary. This sets the action that shall be
     /// performed when the annotation receives the input focus. Only permissible
     /// for widget annotations. PDF 1.2+.
-    pub fn widgetfocus(&mut self) -> Action<'_> {
+    pub fn widget_focus(&mut self) -> Action<'_> {
         self.insert(Name(b"Fo")).start()
     }
 
     /// Start writing the `/Bl` dictionary. This sets the action that shall be
     /// performed when the annotation loses the input focus. Only permissible
     /// for widget annotations. PDF 1.2+.
-    pub fn widgetfocus_loss(&mut self) -> Action<'_> {
+    pub fn widget_focus_loss(&mut self) -> Action<'_> {
         self.insert(Name(b"Bl")).start()
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -208,58 +208,58 @@ writer!(AdditionalActions: |obj| Self { dict: obj.dict() });
 /// Only permissible for [annotations](Annotation).
 impl<'a> AdditionalActions<'a> {
     /// Start writing the `/E` dictionary. An action that shall be performed
-    /// when the cursor enters the annotation’s active area. Only permissible
+    /// when the cursor enters the annotation's active area. Only permissible
     /// for annotations. PDF 1.2+.
     pub fn curser_enter(&mut self) -> Action<'_> {
         self.insert(Name(b"E")).start()
     }
 
     /// Start writing the `/X` dictionary. An action that shall be performed
-    /// when the cursor exits the annotation’s active area. Only permissible for
+    /// when the cursor exits the annotation's active area. Only permissible for
     /// annotations. PDF 1.2+.
     pub fn cursor_exit(&mut self) -> Action<'_> {
         self.insert(Name(b"X")).start()
     }
 
-    /// Start writing the `/D` dictionary. An action that shall be performed
-    /// when the mouse button is pressed inside the annotation’s active area.
-    /// Only permissible for annotations. PDF 1.2+.
+    /// Start writing the `/D` dictionary. This sets the action action
+    /// that shall be performed when the mouse button is pressed inside the
+    /// annotation's active area. Only permissible for annotations. PDF 1.2+.
     pub fn mouse_press(&mut self) -> Action<'_> {
         self.insert(Name(b"D")).start()
     }
 
-    /// Start writing the `/U` dictionary. An action that shall be performed
-    /// when the mouse button is released inside the annotation’s active area.
-    /// Only permissible for annotations. PDF 1.2+.
+    /// Start writing the `/U` dictionary. This sets the action action that
+    /// shall be performed when the mouse button is released inside the
+    /// annotation's active area. Only permissible for annotations. PDF 1.2+.
     pub fn mouse_release(&mut self) -> Action<'_> {
         self.insert(Name(b"U")).start()
     }
 
-    /// Start writing the `/PO` dictionary. An action that shall be performed
-    /// when the page containing the annotation is opened. Only permissible for
-    /// annotations. PDF 1.5+.
+    /// Start writing the `/PO` dictionary. This sets the action action that
+    /// shall be performed when the page containing the annotation is opened.
+    /// Only permissible for annotations. PDF 1.5+.
     pub fn page_open(&mut self) -> Action<'_> {
         self.insert(Name(b"PO")).start()
     }
 
-    /// Start writing the `/PC` dictionary. An action that shall be performed
-    /// when the page containing the annotation is closed. Only permissible for
-    /// annotations. PDF 1.5+.
+    /// Start writing the `/PC` dictionary. This sets the action action that
+    /// shall be performed when the page containing the annotation is closed.
+    /// Only permissible for annotations. PDF 1.5+.
     pub fn page_close(&mut self) -> Action<'_> {
         self.insert(Name(b"PV")).start()
     }
 
-    /// Start writing the `/PV` dictionary. An action that shall be performed
-    /// when the page containing the annotation becomes visible. Only
-    /// permissible for annotations. PDF 1.5+.
+    /// Start writing the `/PV` dictionary. This sets the action action that
+    /// shall be performed when the page containing the annotation becomes
+    /// visible. Only permissible for annotations. PDF 1.5+.
     pub fn page_visible(&mut self) -> Action<'_> {
         self.insert(Name(b"PV")).start()
     }
 
-    /// Start writing the `/PI` dictionary. An action that shall be performed
-    /// when the page containing the annotation is no longer visible in the
-    /// conforming reader’s user interface. Only permissible for annotations.
-    /// PDF 1.5+.
+    /// Start writing the `/PI` dictionary. This sets the action action that
+    /// shall be performed when the page containing the annotation is no longer
+    /// visible in the conforming reader's user interface. Only permissible for
+    /// annotations. PDF 1.5+.
     pub fn page_invisible(&mut self) -> Action<'_> {
         self.insert(Name(b"PI")).start()
     }
@@ -268,16 +268,16 @@ impl<'a> AdditionalActions<'a> {
 /// Only permissible for [widget](crate::types::AnnotationType::Widget)
 /// [annotations](Annotation).
 impl<'a> AdditionalActions<'a> {
-    /// Start writing the `/Fo` dictionary. An action that shall be performed
-    /// when the annotation receives the input focus.
-    /// Only permissible for widget annotations. PDF 1.2+.
+    /// Start writing the `/Fo` dictionary. This sets the action that shall be
+    /// performed when the annotation receives the input focus. Only permissible
+    /// for widget annotations. PDF 1.2+.
     pub fn focus(&mut self) -> Action<'_> {
         self.insert(Name(b"Fo")).start()
     }
 
-    /// Start writing the `/Bl` dictionary. An action that shall be performed
-    /// when the annotation loses the input focus. Only permissible for widget
-    /// annotations. PDF 1.2+.
+    /// Start writing the `/Bl` dictionary. This sets the action that shall be
+    /// performed when the annotation loses the input focus. Only permissible
+    /// for widget annotations. PDF 1.2+.
     pub fn focus_loss(&mut self) -> Action<'_> {
         self.insert(Name(b"Bl")).start()
     }
@@ -309,27 +309,32 @@ impl<'a> AdditionalActions<'a> {
     /// shall be performed when the user modifies a character in a text field
     /// or combo box or modifies the selection in a scrollable list box. This
     /// action may check the added text for validity and reject or modify it.
-    /// PDF 1.3+.
+    /// Only permissible for form fields. PDF 1.3+.
     pub fn k(&mut self) -> Action<'_> {
         self.insert(Name(b"K")).start()
     }
-    /// Start writing the `/F` dictionary. This sets the JavaScript action that
-    /// shall be performed before the field is formatted to display its value.
-    /// This action may modify the field's value before formatting. PDF 1.3+.
+
+    /// Start writing the `/F` dictionary. This sets the JavaScript action
+    /// that shall be performed before the field is formatted to display its
+    /// value. This action may modify the field's value before formatting. Only
+    /// permissible for form fields. PDF 1.3+.
     pub fn format(&mut self) -> Action<'_> {
         self.insert(Name(b"F")).start()
     }
+
     /// Start writing the `/V` dictionary. This sets the JavaScript action that
     /// shall be performed when the field's value is changed. This action may
-    /// check the new value for validity. PDF 1.3+.
+    /// check the new value for validity. Only permissible for form fields.
+    /// PDF 1.3+.
     pub fn validate(&mut self) -> Action<'_> {
         self.insert(Name(b"V")).start()
     }
+
     /// Start writing the `/C` dictionary. This sets the JavaScript action that
     /// shall be performed to recalculate the value of this field when that
     /// of another field changes. The order in which the document's fields are
     /// recalculated shall be defined by the `/CO` entry in the interactive form
-    /// dictionary. PDF 1.3+.
+    /// dictionary. Only permissible for form fields. PDF 1.3+.
     pub fn calculate(&mut self) -> Action<'_> {
         self.insert(Name(b"C")).start()
     }
@@ -337,32 +342,37 @@ impl<'a> AdditionalActions<'a> {
 
 /// Only permisible for [document catalog](Catalog).
 impl<'a> AdditionalActions<'a> {
-    /// Start writing the `/WC` dictionary. This sets the JavaScript action that
-    /// shall be performed before closing a document. PDF 1.4+.
+    /// Start writing the `/WC` dictionary. This sets the JavaScript action
+    /// that shall be performed before closing a document. Only permissible for
+    /// [document catalog](Catalog) PDF 1.4+.
     pub fn before_close(&mut self) -> Action<'_> {
         self.insert(Name(b"WC")).start()
     }
 
-    /// Start writing the `/WS` dictionary. This sets the JavaScript action that
-    /// shall be performed before saving a document. PDF 1.4+.
+    /// Start writing the `/WS` dictionary. This sets the JavaScript action
+    /// that shall be performed before saving a document. Only permissible for
+    /// [document catalog](Catalog) PDF 1.4+.
     pub fn before_save(&mut self) -> Action<'_> {
         self.insert(Name(b"WS")).start()
     }
 
-    /// Start writing the `/DS` dictionary. This sets the JavaScript action that
-    /// shall be performed after saving a document. PDF 1.4+.
+    /// Start writing the `/DS` dictionary. This sets the JavaScript action
+    /// that shall be performed after saving a document. Only permissible for
+    /// [document catalog](Catalog) PDF 1.4+.
     pub fn after_save(&mut self) -> Action<'_> {
         self.insert(Name(b"DS")).start()
     }
 
-    /// Start writing the `/WP` dictionary. This sets the JavaScript action that
-    /// shall be performed before printing a document. PDF 1.4+.
+    /// Start writing the `/WP` dictionary. This sets the JavaScript action
+    /// that shall be performed before printing a document. Only permissible for
+    /// [document catalog](Catalog) PDF 1.4+.
     pub fn before_print(&mut self) -> Action<'_> {
         self.insert(Name(b"WP")).start()
     }
 
-    /// Start writing the `/DP` dictionary. This sets the JavaScript action that
-    /// shall be performed after printing a document. PDF 1.4+.
+    /// Start writing the `/DP` dictionary. This sets the JavaScript action
+    /// that shall be performed after printing a document. Only permissible for
+    /// [document catalog](Catalog) PDF 1.4+.
     pub fn after_print(&mut self) -> Action<'_> {
         self.insert(Name(b"DP")).start()
     }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -86,3 +86,146 @@ impl ActionType {
         }
     }
 }
+
+/// Writer for an _additional actions dictionary_.
+///
+/// This struct is created by [`Annotation::additional_actions`],
+/// [`Page::additional_actions`] and [`Catalog::additional_actions`].
+pub struct AdditionalActions<'a> {
+    dict: Dict<'a>,
+}
+
+writer!(AdditionalActions: |obj| Self { dict: obj.dict() });
+
+/// Only permissible for [annotations](Annotation).
+impl<'a> AdditionalActions<'a> {
+    /// Start writing the `/E` dictionary. An action that shall be performed
+    /// when the cursor enters the annotation’s active area. Only permissible
+    /// for annotations. PDF 1.2+.
+    pub fn curser_enter(&mut self) -> Action<'_> {
+        self.insert(Name(b"E")).start()
+    }
+
+    /// Start writing the `/X` dictionary. An action that shall be performed
+    /// when the cursor exits the annotation’s active area. Only permissible for
+    /// annotations. PDF 1.2+.
+    pub fn cursor_exit(&mut self) -> Action<'_> {
+        self.insert(Name(b"X")).start()
+    }
+
+    /// Start writing the `/D` dictionary. An action that shall be performed
+    /// when the mouse button is pressed inside the annotation’s active area.
+    /// Only permissible for annotations. PDF 1.2+.
+    pub fn mouse_press(&mut self) -> Action<'_> {
+        self.insert(Name(b"D")).start()
+    }
+
+    /// Start writing the `/U` dictionary. An action that shall be performed
+    /// when the mouse button is released inside the annotation’s active area.
+    /// Only permissible for annotations. PDF 1.2+.
+    pub fn mouse_release(&mut self) -> Action<'_> {
+        self.insert(Name(b"U")).start()
+    }
+
+    /// Start writing the `/PO` dictionary. An action that shall be performed
+    /// when the page containing the annotation is opened. Only permissible for
+    /// annotations. PDF 1.5+.
+    pub fn page_open(&mut self) -> Action<'_> {
+        self.insert(Name(b"PO")).start()
+    }
+
+    /// Start writing the `/PC` dictionary. An action that shall be performed
+    /// when the page containing the annotation is closed. Only permissible for
+    /// annotations. PDF 1.5+.
+    pub fn page_close(&mut self) -> Action<'_> {
+        self.insert(Name(b"PV")).start()
+    }
+
+    /// Start writing the `/PV` dictionary. An action that shall be performed
+    /// when the page containing the annotation becomes visible. Only
+    /// permissible for annotations. PDF 1.5+.
+    pub fn page_visible(&mut self) -> Action<'_> {
+        self.insert(Name(b"PV")).start()
+    }
+
+    /// Start writing the `/PI` dictionary. An action that shall be performed
+    /// when the page containing the annotation is no longer visible in the
+    /// conforming reader’s user interface. Only permissible for annotations.
+    /// PDF 1.5+.
+    pub fn page_invisible(&mut self) -> Action<'_> {
+        self.insert(Name(b"PI")).start()
+    }
+}
+
+/// Only permissible for [widget](crate::types::AnnotationType::Widget)
+/// [annotations](Annotation).
+impl<'a> AdditionalActions<'a> {
+    /// Start writing the `/Fo` dictionary. An action that shall be performed
+    /// when the annotation receives the input focus.
+    /// Only permissible for widget annotations. PDF 1.2+.
+    pub fn focus(&mut self) -> Action<'_> {
+        self.insert(Name(b"Fo")).start()
+    }
+
+    /// Start writing the `/Bl` dictionary. An action that shall be performed
+    /// when the annotation loses the input focus. Only permissible for widget
+    /// annotations. PDF 1.2+.
+    pub fn focus_loss(&mut self) -> Action<'_> {
+        self.insert(Name(b"Bl")).start()
+    }
+}
+
+/// Only permissible for [page objects](Page).
+impl<'a> AdditionalActions<'a> {
+    /// Start writing the `/O` dictionary. This sets the action that shall be
+    /// performed when the page is opened. This action is independent of any
+    /// that may be defined by the open action entry in the
+    /// [document catalog](Catalog) and shall be executed after such an action.
+    /// Only permissible for [page objects](Page). PDF 1.2+.
+    pub fn open(&mut self) -> Action<'_> {
+        self.insert(Name(b"O")).start()
+    }
+
+    /// Start writing the `/C` dictionary. This sets the action that shall
+    /// be performed when the page is closed. This action applies to the page
+    /// being closed and shall be executed before any other page is opened. Only
+    /// permissible for [page objects](Page). PDF 1.2+.
+    pub fn close(&mut self) -> Action<'_> {
+        self.insert(Name(b"C")).start()
+    }
+}
+
+/// Only permisible for [document catalog](Catalog).
+impl<'a> AdditionalActions<'a> {
+    /// Start writing the `/WC` dictionary. This sets the JavaScript action that
+    /// shall be performed before closing a document. PDF 1.4+.
+    pub fn before_close(&mut self) -> Action<'_> {
+        self.insert(Name(b"WC")).start()
+    }
+
+    /// Start writing the `/WS` dictionary. This sets the JavaScript action that
+    /// shall be performed before saving a document. PDF 1.4+.
+    pub fn before_save(&mut self) -> Action<'_> {
+        self.insert(Name(b"WS")).start()
+    }
+
+    /// Start writing the `/DS` dictionary. This sets the JavaScript action that
+    /// shall be performed after saving a document. PDF 1.4+.
+    pub fn after_save(&mut self) -> Action<'_> {
+        self.insert(Name(b"DS")).start()
+    }
+
+    /// Start writing the `/WP` dictionary. This sets the JavaScript action that
+    /// shall be performed before printing a document. PDF 1.4+.
+    pub fn before_print(&mut self) -> Action<'_> {
+        self.insert(Name(b"WP")).start()
+    }
+
+    /// Start writing the `/DP` dictionary. This sets the JavaScript action that
+    /// shall be performed after printing a document. PDF 1.4+.
+    pub fn after_print(&mut self) -> Action<'_> {
+        self.insert(Name(b"DP")).start()
+    }
+}
+
+deref!('a, AdditionalActions<'a> => Dict<'a>, dict);

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -2,7 +2,8 @@ use super::*;
 
 /// Writer for an _action dictionary_.
 ///
-/// This struct is created by [`Annotation::action`].
+/// This struct is created by [`Annotation::action`] and many keys of
+/// [`AdditionalActions`].
 pub struct Action<'a> {
     dict: Dict<'a>,
 }
@@ -65,15 +66,15 @@ impl<'a> Action<'a> {
     }
 
     /// Start writing the `/Fields` array to set the fields which are
-    /// [include/exclude](ActionFlags::INCLUDE_EXCLUDE) when submitting a form
-    /// or loading an FDF file.
+    /// [include/exclude](ActionFlags::INCLUDE_EXCLUDE) when submitting a form,
+    /// resetting a form or loading an FDF file.
     pub fn fields(&mut self) -> Fields<'_> {
         self.insert(Name(b"Fields")).start()
     }
 
-    /// Write the `/Flags` attribute to set the various characteristics of the
+    /// Write the `/Flags` attribute to set the various characteristics of form
     /// action.
-    pub fn flags(&mut self, flags: ActionFlags) -> &mut Self {
+    pub fn form_flags(&mut self, flags: FormActionFlags) -> &mut Self {
         self.pair(Name(b"Flags"), flags.bits() as i32);
         self
     }
@@ -141,7 +142,7 @@ impl ActionType {
 
 bitflags::bitflags! {
     /// A set of flags specifying various characteristics of an [`Action`].
-    pub struct ActionFlags: u32 {
+    pub struct FormActionFlags: u32 {
         /// Whether to include (unset) or exclude (set) the values in the
         /// `/Fields` attribute on form submission or reset. This Flag has very
         /// specific interacitons with other flags and fields, read the PDF 1.7
@@ -210,49 +211,49 @@ impl<'a> AdditionalActions<'a> {
     /// Start writing the `/E` dictionary. An action that shall be performed
     /// when the cursor enters the annotation's active area. Only permissible
     /// for annotations. PDF 1.2+.
-    pub fn curser_enter(&mut self) -> Action<'_> {
+    pub fn annot_curser_enter(&mut self) -> Action<'_> {
         self.insert(Name(b"E")).start()
     }
 
     /// Start writing the `/X` dictionary. An action that shall be performed
     /// when the cursor exits the annotation's active area. Only permissible for
     /// annotations. PDF 1.2+.
-    pub fn cursor_exit(&mut self) -> Action<'_> {
+    pub fn annot_cursor_exit(&mut self) -> Action<'_> {
         self.insert(Name(b"X")).start()
     }
 
     /// Start writing the `/D` dictionary. This sets the action action
     /// that shall be performed when the mouse button is pressed inside the
     /// annotation's active area. Only permissible for annotations. PDF 1.2+.
-    pub fn mouse_press(&mut self) -> Action<'_> {
+    pub fn annot_mouse_press(&mut self) -> Action<'_> {
         self.insert(Name(b"D")).start()
     }
 
     /// Start writing the `/U` dictionary. This sets the action action that
     /// shall be performed when the mouse button is released inside the
     /// annotation's active area. Only permissible for annotations. PDF 1.2+.
-    pub fn mouse_release(&mut self) -> Action<'_> {
+    pub fn annot_mouse_release(&mut self) -> Action<'_> {
         self.insert(Name(b"U")).start()
     }
 
     /// Start writing the `/PO` dictionary. This sets the action action that
     /// shall be performed when the page containing the annotation is opened.
     /// Only permissible for annotations. PDF 1.5+.
-    pub fn page_open(&mut self) -> Action<'_> {
+    pub fn annot_page_open(&mut self) -> Action<'_> {
         self.insert(Name(b"PO")).start()
     }
 
     /// Start writing the `/PC` dictionary. This sets the action action that
     /// shall be performed when the page containing the annotation is closed.
     /// Only permissible for annotations. PDF 1.5+.
-    pub fn page_close(&mut self) -> Action<'_> {
+    pub fn annot_page_close(&mut self) -> Action<'_> {
         self.insert(Name(b"PV")).start()
     }
 
     /// Start writing the `/PV` dictionary. This sets the action action that
     /// shall be performed when the page containing the annotation becomes
     /// visible. Only permissible for annotations. PDF 1.5+.
-    pub fn page_visible(&mut self) -> Action<'_> {
+    pub fn annot_page_visible(&mut self) -> Action<'_> {
         self.insert(Name(b"PV")).start()
     }
 
@@ -260,7 +261,7 @@ impl<'a> AdditionalActions<'a> {
     /// shall be performed when the page containing the annotation is no longer
     /// visible in the conforming reader's user interface. Only permissible for
     /// annotations. PDF 1.5+.
-    pub fn page_invisible(&mut self) -> Action<'_> {
+    pub fn annot_page_invisible(&mut self) -> Action<'_> {
         self.insert(Name(b"PI")).start()
     }
 }
@@ -271,14 +272,14 @@ impl<'a> AdditionalActions<'a> {
     /// Start writing the `/Fo` dictionary. This sets the action that shall be
     /// performed when the annotation receives the input focus. Only permissible
     /// for widget annotations. PDF 1.2+.
-    pub fn focus(&mut self) -> Action<'_> {
+    pub fn widgetfocus(&mut self) -> Action<'_> {
         self.insert(Name(b"Fo")).start()
     }
 
     /// Start writing the `/Bl` dictionary. This sets the action that shall be
     /// performed when the annotation loses the input focus. Only permissible
     /// for widget annotations. PDF 1.2+.
-    pub fn focus_loss(&mut self) -> Action<'_> {
+    pub fn widgetfocus_loss(&mut self) -> Action<'_> {
         self.insert(Name(b"Bl")).start()
     }
 }
@@ -290,7 +291,7 @@ impl<'a> AdditionalActions<'a> {
     /// that may be defined by the open action entry in the
     /// [document catalog](Catalog) and shall be executed after such an action.
     /// Only permissible for [page objects](Page). PDF 1.2+.
-    pub fn open(&mut self) -> Action<'_> {
+    pub fn page_open(&mut self) -> Action<'_> {
         self.insert(Name(b"O")).start()
     }
 
@@ -298,7 +299,7 @@ impl<'a> AdditionalActions<'a> {
     /// be performed when the page is closed. This action applies to the page
     /// being closed and shall be executed before any other page is opened. Only
     /// permissible for [page objects](Page). PDF 1.2+.
-    pub fn close(&mut self) -> Action<'_> {
+    pub fn page_close(&mut self) -> Action<'_> {
         self.insert(Name(b"C")).start()
     }
 }
@@ -310,7 +311,7 @@ impl<'a> AdditionalActions<'a> {
     /// or combo box or modifies the selection in a scrollable list box. This
     /// action may check the added text for validity and reject or modify it.
     /// Only permissible for form fields. PDF 1.3+.
-    pub fn k(&mut self) -> Action<'_> {
+    pub fn form_calculate_partial(&mut self) -> Action<'_> {
         self.insert(Name(b"K")).start()
     }
 
@@ -318,7 +319,7 @@ impl<'a> AdditionalActions<'a> {
     /// that shall be performed before the field is formatted to display its
     /// value. This action may modify the field's value before formatting. Only
     /// permissible for form fields. PDF 1.3+.
-    pub fn format(&mut self) -> Action<'_> {
+    pub fn form_format(&mut self) -> Action<'_> {
         self.insert(Name(b"F")).start()
     }
 
@@ -326,7 +327,7 @@ impl<'a> AdditionalActions<'a> {
     /// shall be performed when the field's value is changed. This action may
     /// check the new value for validity. Only permissible for form fields.
     /// PDF 1.3+.
-    pub fn validate(&mut self) -> Action<'_> {
+    pub fn form_validate(&mut self) -> Action<'_> {
         self.insert(Name(b"V")).start()
     }
 
@@ -335,7 +336,7 @@ impl<'a> AdditionalActions<'a> {
     /// of another field changes. The order in which the document's fields are
     /// recalculated shall be defined by the `/CO` entry in the interactive form
     /// dictionary. Only permissible for form fields. PDF 1.3+.
-    pub fn calculate(&mut self) -> Action<'_> {
+    pub fn form_calculate(&mut self) -> Action<'_> {
         self.insert(Name(b"C")).start()
     }
 }
@@ -344,36 +345,36 @@ impl<'a> AdditionalActions<'a> {
 impl<'a> AdditionalActions<'a> {
     /// Start writing the `/WC` dictionary. This sets the JavaScript action
     /// that shall be performed before closing a document. Only permissible for
-    /// [document catalog](Catalog) PDF 1.4+.
-    pub fn before_close(&mut self) -> Action<'_> {
+    /// the [document catalog](Catalog) PDF 1.4+.
+    pub fn cat_before_close(&mut self) -> Action<'_> {
         self.insert(Name(b"WC")).start()
     }
 
     /// Start writing the `/WS` dictionary. This sets the JavaScript action
     /// that shall be performed before saving a document. Only permissible for
-    /// [document catalog](Catalog) PDF 1.4+.
-    pub fn before_save(&mut self) -> Action<'_> {
+    /// the [document catalog](Catalog) PDF 1.4+.
+    pub fn cat_before_save(&mut self) -> Action<'_> {
         self.insert(Name(b"WS")).start()
     }
 
     /// Start writing the `/DS` dictionary. This sets the JavaScript action
     /// that shall be performed after saving a document. Only permissible for
-    /// [document catalog](Catalog) PDF 1.4+.
-    pub fn after_save(&mut self) -> Action<'_> {
+    /// the [document catalog](Catalog) PDF 1.4+.
+    pub fn cat_after_save(&mut self) -> Action<'_> {
         self.insert(Name(b"DS")).start()
     }
 
     /// Start writing the `/WP` dictionary. This sets the JavaScript action
     /// that shall be performed before printing a document. Only permissible for
-    /// [document catalog](Catalog) PDF 1.4+.
-    pub fn before_print(&mut self) -> Action<'_> {
+    /// the [document catalog](Catalog) PDF 1.4+.
+    pub fn cat_before_print(&mut self) -> Action<'_> {
         self.insert(Name(b"WP")).start()
     }
 
     /// Start writing the `/DP` dictionary. This sets the JavaScript action
     /// that shall be performed after printing a document. Only permissible for
-    /// [document catalog](Catalog) PDF 1.4+.
-    pub fn after_print(&mut self) -> Action<'_> {
+    /// the [document catalog](Catalog) PDF 1.4+.
+    pub fn cat_after_print(&mut self) -> Action<'_> {
         self.insert(Name(b"DP")).start()
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -65,6 +65,13 @@ impl<'a> Action<'a> {
         self
     }
 
+    /// Write the `/JS` attribute to set the script of this action. Only
+    /// permissible for JavaScript actions.
+    pub fn js(&mut self, script: TextStr) -> &mut Self {
+        self.pair(Name(b"JS"), script);
+        self
+    }
+
     /// Start writing the `/Fields` array to set the fields which are
     /// [include/exclude](ActionFlags::INCLUDE_EXCLUDE) when submitting a form,
     /// resetting a form or loading an FDF file.
@@ -124,6 +131,8 @@ pub enum ActionType {
     ResetForm,
     /// Import form field values from a file. PDF 1.2+.
     ImportData,
+    /// Execute a JavaScript action. PDF 1.2+.
+    JavaScript,
 }
 
 impl ActionType {
@@ -136,6 +145,7 @@ impl ActionType {
             Self::SubmitForm => Name(b"SubmitForm"),
             Self::ResetForm => Name(b"ResetForm"),
             Self::ImportData => Name(b"ImportData"),
+            Self::JavaScript => Name(b"JavaScript"),
         }
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -303,6 +303,38 @@ impl<'a> AdditionalActions<'a> {
     }
 }
 
+/// Only permisible for form fields.
+impl<'a> AdditionalActions<'a> {
+    /// Start writing the `/K` dictionary. This sets the JavaScript action that
+    /// shall be performed when the user modifies a character in a text field
+    /// or combo box or modifies the selection in a scrollable list box. This
+    /// action may check the added text for validity and reject or modify it.
+    /// PDF 1.3+.
+    pub fn k(&mut self) -> Action<'_> {
+        self.insert(Name(b"K")).start()
+    }
+    /// Start writing the `/F` dictionary. This sets the JavaScript action that
+    /// shall be performed before the field is formatted to display its value.
+    /// This action may modify the field's value before formatting. PDF 1.3+.
+    pub fn format(&mut self) -> Action<'_> {
+        self.insert(Name(b"F")).start()
+    }
+    /// Start writing the `/V` dictionary. This sets the JavaScript action that
+    /// shall be performed when the field's value is changed. This action may
+    /// check the new value for validity. PDF 1.3+.
+    pub fn validate(&mut self) -> Action<'_> {
+        self.insert(Name(b"V")).start()
+    }
+    /// Start writing the `/C` dictionary. This sets the JavaScript action that
+    /// shall be performed to recalculate the value of this field when that
+    /// of another field changes. The order in which the document's fields are
+    /// recalculated shall be defined by the `/CO` entry in the interactive form
+    /// dictionary. PDF 1.3+.
+    pub fn calculate(&mut self) -> Action<'_> {
+        self.insert(Name(b"C")).start()
+    }
+}
+
 /// Only permisible for [document catalog](Catalog).
 impl<'a> AdditionalActions<'a> {
     /// Start writing the `/WC` dictionary. This sets the JavaScript action that

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -322,69 +322,6 @@ bitflags::bitflags! {
     }
 }
 
-/// Writer for an _action dictionary_.
-///
-/// This struct is created by [`Annotation::action`].
-pub struct Action<'a> {
-    dict: Dict<'a>,
-}
-
-writer!(Action: |obj| {
-    let mut dict = obj.dict();
-    dict.pair(Name(b"Type"), Name(b"Action"));
-    Self { dict }
-});
-
-impl<'a> Action<'a> {
-    /// Write the `/S` attribute to set the action type.
-    pub fn action_type(&mut self, kind: ActionType) -> &mut Self {
-        self.pair(Name(b"S"), kind.to_name());
-        self
-    }
-
-    /// Start writing the `/D` attribute to set the destination of this
-    /// GoTo-type action.
-    pub fn destination(&mut self) -> Destination<'_> {
-        self.insert(Name(b"D")).start()
-    }
-
-    /// Write the `/D` attribute to set the destination of this GoTo-type action
-    /// to a named destination.
-    pub fn destination_named(&mut self, name: Name) -> &mut Self {
-        self.pair(Name(b"D"), name);
-        self
-    }
-
-    /// Start writing the `/F` attribute, setting which file to go to or which
-    /// application to launch.
-    pub fn file_spec(&mut self) -> FileSpec<'_> {
-        self.insert(Name(b"F")).start()
-    }
-
-    /// Write the `/NewWindow` attribute to set whether this remote GoTo action
-    /// should open the referenced destination in another window.
-    pub fn new_window(&mut self, new: bool) -> &mut Self {
-        self.pair(Name(b"NewWindow"), new);
-        self
-    }
-
-    /// Write the `/URI` attribute to set where this link action goes.
-    pub fn uri(&mut self, uri: Str) -> &mut Self {
-        self.pair(Name(b"URI"), uri);
-        self
-    }
-
-    /// Write the `/IsMap` attribute to set if the click position of the user's
-    /// cursor inside the link rectangle should be appended to the referenced
-    /// URI as a query parameter.
-    pub fn is_map(&mut self, map: bool) -> &mut Self {
-        self.pair(Name(b"IsMap"), map);
-        self
-    }
-}
-
-deref!('a, Action<'a> => Dict<'a>, dict);
-
 /// Writer for an _appearance dictionary_.
 ///
 /// This struct is created by [`Annotation::appearance`].
@@ -628,30 +565,6 @@ impl IconScaleType {
         match self {
             Self::Anamorphic => Name(b"A"),
             Self::Proportional => Name(b"P"),
-        }
-    }
-}
-
-/// What kind of action to perform when clicking a link annotation.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum ActionType {
-    /// Go to a destination in the document.
-    GoTo,
-    /// Go to a destination in another document.
-    RemoteGoTo,
-    /// Launch an application.
-    Launch,
-    /// Open a URI.
-    Uri,
-}
-
-impl ActionType {
-    pub(crate) fn to_name(self) -> Name<'static> {
-        match self {
-            Self::GoTo => Name(b"GoTo"),
-            Self::RemoteGoTo => Name(b"GoToR"),
-            Self::Launch => Name(b"Launch"),
-            Self::Uri => Name(b"URI"),
         }
     }
 }

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -128,6 +128,12 @@ impl<'a> Annotation<'a> {
         self.insert(Name(b"A")).start()
     }
 
+    /// Start writing the `/AA` dictionary. Only permissible for the subtype
+    /// `Widget`. PDF 1.3+.
+    pub fn additional_actions(&mut self) -> AdditionalActions<'_> {
+        self.insert(Name(b"AA")).start()
+    }
+
     /// Write the `/H` attribute to set what effect is used to convey that the
     /// user is pressing a link or widget annotation. Only permissible for the
     /// subtypes `Link` and `Widget`. PDF 1.2+.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod xobject;
 /// Strongly typed writers for specific PDF structures.
 pub mod writers {
     use super::*;
-    pub use actions::Action;
+    pub use actions::{Action, AdditionalActions};
     pub use annotations::{Annotation, Appearance, BorderStyle, IconFit};
     pub use attributes::{
         Attributes, FieldAttributes, LayoutAttributes, ListAttributes, TableAttributes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod xobject;
 /// Strongly typed writers for specific PDF structures.
 pub mod writers {
     use super::*;
-    pub use actions::{Action, AdditionalActions};
+    pub use actions::{Action, AdditionalActions, Fields};
     pub use annotations::{Annotation, Appearance, BorderStyle, IconFit};
     pub use attributes::{
         Attributes, FieldAttributes, LayoutAttributes, ListAttributes, TableAttributes,
@@ -141,7 +141,7 @@ pub mod writers {
 /// Types used by specific PDF structures.
 pub mod types {
     use super::*;
-    pub use actions::ActionType;
+    pub use actions::{ActionFlags, ActionType};
     pub use annotations::{
         AnnotationFlags, AnnotationIcon, AnnotationType, BorderType, HighlightEffect,
         IconScale, IconScaleType, TextPosition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub mod writers {
 /// Types used by specific PDF structures.
 pub mod types {
     use super::*;
-    pub use actions::{ActionFlags, ActionType};
+    pub use actions::{ActionType, FormActionFlags};
     pub use annotations::{
         AnnotationFlags, AnnotationIcon, AnnotationType, BorderType, HighlightEffect,
         IconScale, IconScaleType, TextPosition,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ valid PDFs.
 
 #[macro_use]
 mod macros;
+mod actions;
 mod annotations;
 mod attributes;
 mod buf;
@@ -104,7 +105,8 @@ mod xobject;
 /// Strongly typed writers for specific PDF structures.
 pub mod writers {
     use super::*;
-    pub use annotations::{Action, Annotation, Appearance, BorderStyle, IconFit};
+    pub use actions::Action;
+    pub use annotations::{Annotation, Appearance, BorderStyle, IconFit};
     pub use attributes::{
         Attributes, FieldAttributes, LayoutAttributes, ListAttributes, TableAttributes,
         UserProperty,
@@ -139,9 +141,10 @@ pub mod writers {
 /// Types used by specific PDF structures.
 pub mod types {
     use super::*;
+    pub use actions::ActionType;
     pub use annotations::{
-        ActionType, AnnotationFlags, AnnotationIcon, AnnotationType, BorderType,
-        HighlightEffect, IconScale, IconScaleType, TextPosition,
+        AnnotationFlags, AnnotationIcon, AnnotationType, BorderType, HighlightEffect,
+        IconScale, IconScaleType, TextPosition,
     };
     pub use attributes::{
         AttributeOwner, BlockAlign, FieldRole, FieldState, InlineAlign,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -91,6 +91,12 @@ impl<'a> Catalog<'a> {
         self
     }
 
+    /// Start writing the `/AA` dictionary. This sets the additional actions for
+    /// the whole document. PDF 1.4+.
+    pub fn additional_actions(&mut self) -> AdditionalActions<'_> {
+        self.insert(Name(b"AA")).start()
+    }
+
     /// Write the `/Metadata` attribute to specify the document's metadata. PDF
     /// 1.4+.
     ///
@@ -1185,6 +1191,12 @@ impl<'a> Page<'a> {
     pub fn user_unit(&mut self, value: f32) -> &mut Self {
         self.pair(Name(b"UserUnit"), value);
         self
+    }
+
+    /// Start writing the `/AA` dictionary. This sets the actions to perform
+    /// when a page is opened or closed. PDF 1.2+.
+    pub fn additional_actions(&mut self) -> AdditionalActions<'_> {
+        self.insert(Name(b"AA")).start()
     }
 
     /// Write the `/Metadata` attribute to specify the page's metadata. PDF


### PR DESCRIPTION
This PR adds the writers and types for writing additional action dictionaries used for various trigger events. This PR also extends existing writers and types to support interactive form related actions.

As noted in #20, `/AA` was added to the writers which expose it according to PDF 1.7.

~~The `/K`, `/F`, `/v` and `/C` attributes were left out as they are part of form fields and will be added alongside those.~~ Since I'm adding submit form actions and others I may as well add these too.