### PR TITLE
Feature: Form Field types (PDF 1.7 Section 12.7.4)

### DIFF
--- a/src/forms.rs
+++ b/src/forms.rs
@@ -7,6 +7,7 @@ pub struct Field<'a> {
 
 writer!(Field: |obj| Self { dict: obj.dict() });
 
+/// Permissible on all fields.
 impl<'a> Field<'a> {
     /// Write the `/FT` attribute to set the type of this field.
     pub fn field_type(&mut self, typ: FieldType) -> &mut Self {
@@ -76,7 +77,50 @@ impl<'a> Field<'a> {
     }
 }
 
+/// Permissible on fields containing variable text.
+impl<'a> Field<'a> {
+    /// Write the `/DA` attribute containing a sequence of valid page-content
+    /// graphics or text state operators that define such properties as the
+    /// field's text size and colour.
+    pub fn default_appearance(&mut self, appearance: Str) -> &mut Self {
+        self.dict.pair(Name(b"DA"), appearance);
+        self
+    }
+
+    /// Write the `/Q` attribute to set the quadding (justification) that shall
+    /// be used in dispalying the text.
+    pub fn quadding(&mut self, quadding: Quadding) -> &mut Self {
+        self.dict.pair(Name(b"Q"), quadding as u32 as i32);
+        self
+    }
+
+    /// Write the `/DS` attribute to set the default style string. PDF 1.5+.
+    pub fn default_style(&mut self, style: TextStr) -> &mut Self {
+        self.dict.pair(Name(b"DS"), style);
+        self
+    }
+
+    /// Write the `/RV` attribute to set the value of this variable text field.
+    /// PDF 1.5+.
+    pub fn rich_value(&mut self, value: TextStr) -> &mut Self {
+        self.dict.pair(Name(b"RV"), value);
+        self
+    }
+}
+
 deref!('a, Field<'a> => Dict<'a>, dict);
+
+/// The quadding (justification) of a field containing variable text.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(u32)]
+pub enum Quadding {
+    /// Left justify the text.
+    Left = 0,
+    /// Center justify the text.
+    Center = 1,
+    /// Right justify the text.
+    Right = 2,
+}
 
 /// The type of a [`Field`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -247,6 +247,27 @@ impl<'a> Field<'a> {
     }
 }
 
+/// Only permissible on radio button fields.
+impl<'a> Field<'a> {
+    /// Write the `/V` attribute to set the state of this check box field.
+    /// The state corresponds to an appearance stream in the
+    /// [appearance dictionary](Appearance) of this field's widget
+    /// [annotation](Annotation). Only permissible on radio button fields.
+    pub fn radio_value(&mut self, state: RadioState) -> &mut Self {
+        self.dict.pair(Name(b"V"), state.to_name());
+        self
+    }
+
+    /// Write the `/DV` attribute to set the default state of this check box
+    /// field. The state corresponds to an appearance stream in the
+    /// [appearance dictionary](Appearance) of this field's widget
+    /// [annotation](Annotation). Only permissible on radio button fields.
+    pub fn radio_default_value(&mut self, state: RadioState) -> &mut Self {
+        self.dict.pair(Name(b"DV"), state.to_name());
+        self
+    }
+}
+
 deref!('a, Field<'a> => Dict<'a>, dict);
 
 /// The quadding (justification) of a field containing variable text.
@@ -299,6 +320,23 @@ impl CheckBoxState {
     pub(crate) fn to_name(self) -> Name<'static> {
         match self {
             Self::Yes => Name(b"Yes"),
+            Self::Off => Name(b"Off"),
+        }
+    }
+}
+
+/// The state of a radio button [`Field`].
+pub enum RadioState<'a> {
+    /// The radio button with the given name is selected.
+    Selected(Name<'a>),
+    /// No radio button is selected `/Off`.
+    Off,
+}
+
+impl<'a> RadioState<'a> {
+    pub(crate) fn to_name(self) -> Name<'a> {
+        match self {
+            Self::Selected(name) => name,
             Self::Off => Name(b"Off"),
         }
     }

--- a/src/forms.rs
+++ b/src/forms.rs
@@ -82,14 +82,14 @@ impl<'a> Field<'a> {
     // TODO: the spec likely means the equivalent of unicode graphemes here
     //       for characters
 
-    /// Write the `/MaxLen` attribute to set the maximum length of the fields
+    /// Write the `/MaxLen` attribute to set the maximum length of the field's
     /// text in characters. Only permissible on text fields.
     pub fn text_max_len(&mut self, len: i32) -> &mut Self {
         self.dict.pair(Name(b"MaxLen"), len);
         self
     }
 
-    /// Start writing the `/V` attribute to set the value of this text field.
+    /// Write the `/V` attribute to set the value of this text field.
     /// Only permissible on text fields.
     pub fn text_value(&mut self, value: TextStr) -> &mut Self {
         self.dict.pair(Name(b"V"), value);
@@ -420,15 +420,15 @@ bitflags::bitflags! {
         /// The field’s option items shall be sorted alphabetically. This
         /// flag is intended for use by writers, not by readers.
         const SORT = 1 << 20;
-        /// More than one option of the choice field's may be selected
+        /// More than one option of the choice field may be selected
         /// simultaneously. PDF 1.4+.
         const MULTI_SELECT = 1 << 22;
         /// The new value shall be committed as soon as a selection is made
-        /// (commonly with the pointing device). In this case, supplying a value
-        /// for a field involves three actions: selecting the field for
-        /// fill-in, selecting a choice for the fill-in value, and leaving that
-        /// field, which finalizes or "commits" the data choice and triggers
-        /// any actions associated with the entry or changing of this data.
+        /// (commonly with the mouse). In this case, supplying a value for
+        /// a field involves three actions: selecting the field for fill-in,
+        /// selecting a choice for the fill-in value, and leaving that field,
+        /// which finalizes or "commits" the data choice and triggers any
+        /// actions associated with the entry or changing of this data.
         ///
         /// If set, processing does not wait for leaving the field action to
         /// occur, but immediately proceeds to the third step. PDF 1.5+.


### PR DESCRIPTION
This PR adds the writers and types for writing various types form fields.

- [x] Text Fields
- [x] Choice Fields
- [x] Button Fields
- [ ] ~~Signature Fields~~ (Left out to reduce review surface to in turn ensure correct implementation)