### PR TITLE
write individual destination object

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -191,6 +191,11 @@ impl Chunk {
         self.indirect(id).start()
     }
 
+    /// Start writing a destination for use in a name tree.
+    pub fn destination(&mut self, id: Ref) -> Destination<'_> {
+        self.indirect(id).start()
+    }
+
     /// Start writing a named destination dictionary.
     pub fn destinations(&mut self, id: Ref) -> TypedDict<'_, Destination> {
         self.indirect(id).dict().typed()


### PR DESCRIPTION
Allows individual destinations to be written so that they can be referenced from a name tree. This allows the implementation of "Named destinations" according to PDF 1.2, as described in the specification https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf#M11.9.20535.3Heading.Named.Destinations.

Related: https://github.com/typst/typst/pull/2954.