### PR TITLE
Add a utility trait for objects that contain a resource dictionary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,47 @@ pub mod types {
     pub use xobject::SMaskInData;
 }
 
+/// Dummy
+pub mod traits {
+    use crate::writers::{FormXObject, Page, Pages, Resources, TilingPattern, Type3Font};
+
+    /// Dummy
+    pub trait ResourcesExt {
+        /// Dummy
+        fn resources(&mut self) -> Resources<'_>;
+    }
+
+    impl ResourcesExt for FormXObject<'_> {
+        fn resources(&mut self) -> Resources<'_> {
+            self.resources()
+        }
+    }
+
+    impl ResourcesExt for TilingPattern<'_> {
+        fn resources(&mut self) -> Resources<'_> {
+            self.resources()
+        }
+    }
+
+    impl ResourcesExt for Type3Font<'_> {
+        fn resources(&mut self) -> Resources<'_> {
+            self.resources()
+        }
+    }
+
+    impl ResourcesExt for Pages<'_> {
+        fn resources(&mut self) -> Resources<'_> {
+            self.resources()
+        }
+    }
+
+    impl ResourcesExt for Page<'_> {
+        fn resources(&mut self) -> Resources<'_> {
+            self.resources()
+        }
+    }
+}
+
 pub use self::chunk::Chunk;
 pub use self::content::Content;
 pub use self::object::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,13 +182,13 @@ pub mod types {
     pub use xobject::SMaskInData;
 }
 
-/// Dummy
+/// A number of utility traits that can be used by a consumer.
 pub mod traits {
     use crate::writers::{FormXObject, Page, Pages, Resources, TilingPattern, Type3Font};
 
-    /// Dummy
+    /// A trait for getting the resource dictionary of an object.
     pub trait ResourcesExt {
-        /// Dummy
+        /// Return the resources dictionary of the object.
         fn resources(&mut self) -> Resources<'_>;
     }
 


### PR DESCRIPTION
This allows consumers to write generic functions that take any object as long as it has a resource dictionary, and then act upon that. 