### PR TITLE
Add associated file typed array writers

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -228,6 +228,12 @@ impl<'a> Annotation<'a> {
         self.pair(Name(b"Parent"), id);
         self
     }
+
+    /// Start writing the `/AF` array to specify the associated files of the
+    /// annotation. PDF 2.0+ or PDF/A-3.
+    pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
+        self.insert(Name(b"AF")).array().typed()
+    }
 }
 
 deref!('a, Annotation<'a> => Dict<'a>, dict);

--- a/src/files.rs
+++ b/src/files.rs
@@ -53,13 +53,28 @@ impl<'a> FileSpec<'a> {
     /// PDF 1.3+.
     ///
     /// This only sets an embedded file for the `F` attribute corresponding to
-    /// the [`path`](Self::path) method. You will need to write this dictionary
-    /// manually if you need to set `UF` which is required in PDF/A-3.
+    /// the [`path`](Self::path) method. If you want to set the same embedded
+    /// file for the `UF` attribute, also call [`Self::embedded_file_with_unicode`]
+    /// instead.
     ///
     /// Note that this key is forbidden in PDF/A-1 and restricted in PDF/A-2 and
     /// PDF/A-4.
     pub fn embedded_file(&mut self, id: Ref) -> &mut Self {
         self.insert(Name(b"EF")).dict().pair(Name(b"F"), id);
+        self
+    }
+
+    /// Write the `/EF` attribute to reference an [embedded file](EmbeddedFile)
+    /// for the legacy and Unicode-compatible file path. PDF 1.7+.
+    ///
+    /// Note that this key is forbidden in PDF/A-1 and restricted in PDF/A-2 an
+    /// PDF/A-4.
+    pub fn embedded_file_with_unicode(&mut self, id: Ref) -> &mut Self {
+        let mut path_array = self.insert(Name(b"EF")).dict();
+        path_array.pair(Name(b"F"), id);
+        path_array.pair(Name(b"UF"), id);
+        path_array.finish();
+
         self
     }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -70,11 +70,10 @@ impl<'a> FileSpec<'a> {
     /// Note that this key is forbidden in PDF/A-1 and restricted in PDF/A-2 an
     /// PDF/A-4.
     pub fn embedded_file_with_unicode(&mut self, id: Ref) -> &mut Self {
-        let mut path_array = self.insert(Name(b"EF")).dict();
-        path_array.pair(Name(b"F"), id);
-        path_array.pair(Name(b"UF"), id);
-        path_array.finish();
-
+        self.insert(Name(b"EF"))
+            .dict()
+            .pair(Name(b"F"), id)
+            .pair(Name(b"UF"), id);
         self
     }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -147,7 +147,7 @@ impl<'a> Catalog<'a> {
     }
 
     /// Start writing the `/AF` array to specify the associated files of the
-    /// document. PDF 2.0+.
+    /// document. PDF 2.0+ or PDF/A-3.
     pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
         self.insert(Name(b"AF")).array().typed()
     }
@@ -494,6 +494,12 @@ impl<'a> StructElement<'a> {
     pub fn actual_text(&mut self, actual_text: TextStr) -> &mut Self {
         self.dict.pair(Name(b"ActualText"), actual_text);
         self
+    }
+
+    /// Start writing the `/AF` array to specify the associated files of the
+    /// element. PDF 2.0+ or PDF/A-3.
+    pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
+        self.insert(Name(b"AF")).array().typed()
     }
 }
 
@@ -1246,6 +1252,12 @@ impl<'a> Page<'a> {
     pub fn metadata(&mut self, id: Ref) -> &mut Self {
         self.pair(Name(b"Metadata"), id);
         self
+    }
+
+    /// Start writing the `/AF` array to specify the associated files of the
+    /// page. PDF 2.0+ or PDF/A-3.
+    pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
+        self.insert(Name(b"AF")).array().typed()
     }
 }
 

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -155,6 +155,12 @@ impl<'a> ImageXObject<'a> {
         self.pair(Name(b"Metadata"), id);
         self
     }
+
+    /// Start writing the `/AF` array to specify the associated files of the
+    /// image. PDF 2.0+ or PDF/A-3.
+    pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
+        self.insert(Name(b"AF")).array().typed()
+    }
 }
 
 deref!('a, ImageXObject<'a> => Stream<'a>, stream);
@@ -262,6 +268,12 @@ impl<'a> FormXObject<'a> {
     pub fn last_modified(&mut self, last_modified: Date) -> &mut Self {
         self.pair(Name(b"LastModified"), last_modified);
         self
+    }
+
+    /// Start writing the `/AF` array to specify the associated files of the
+    /// Form XObject. PDF 2.0+ or PDF/A-3.
+    pub fn associated_files(&mut self) -> TypedArray<'_, FileSpec> {
+        self.insert(Name(b"AF")).array().typed()
     }
 }
 


### PR DESCRIPTION
Add a method to reference an embedded file with both the `F` and `UF` paths (PDF/A-3 clause 6.8) and add `/AF` keys to various dictionaries (Annex E). Together with Laurenz' PR, all keys necessary for PDF/A-3 are added.