### PR TITLE
Add structure types and attributes for PDF 2.0

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -59,6 +59,16 @@ impl<'a> Attributes<'a> {
     pub fn artifact(self) -> ArtifactAttributes<'a> {
         ArtifactAttributes::start_with_dict(self.dict)
     }
+
+    /// Set the `/O` attribute to `NSO` and set the `/NS` attribute to an
+    /// indirect reference to a [`Namespace`] dictionary to start writing
+    /// attributes for a namespace. PDF 2.0+
+    pub fn namespace(self, ns: Ref) -> Dict<'a> {
+        let mut dict = self.dict;
+        dict.pair(Name(b"O"), AttributeOwner::NSO.to_name(true));
+        dict.pair(Name(b"NS"), ns);
+        dict
+    }
 }
 
 deref!('a, Attributes<'a> => Dict<'a>, dict);
@@ -973,6 +983,8 @@ pub enum AttributeOwner {
     Rdfa1_1,
     /// ARIA 1.1 accessibility attributes for assistive technology. PDF 2.0+.
     Aria1_1,
+    /// The attribute owner is a namespace. PDF 2.0+.
+    NSO,
     /// User-defined attributes. Requires to set the `/UserProperties` attribute
     /// of the [`MarkInfo`] dictionary to true. PDF 1.6+
     User,
@@ -1004,7 +1016,8 @@ impl AttributeOwner {
             Self::Css3 => Name(b"CSS-3"),
             Self::Rdfa1_1 => Name(b"RDFa-1.10"),
             Self::Aria1_1 => Name(b"ARIA-1.1"),
-            Self::User => Name(b"UserDefined"),
+            Self::NSO => Name(b"NSO"),
+            Self::User => Name(b"UserProperties"),
         }
     }
 }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -69,7 +69,7 @@ impl Buf {
             #[inline(never)]
             fn write_extreme(buf: &mut Buf, value: f32) {
                 use std::io::Write;
-                write!(buf.inner, "{}", value).unwrap();
+                write!(buf.inner, "{value}").unwrap();
             }
 
             write_extreme(self, value);

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -252,6 +252,11 @@ impl Chunk {
         self.indirect(id).start()
     }
 
+    /// Start writing a namespace dictionary. PDF 2.0+
+    pub fn namespace(&mut self, id: Ref) -> Namespace<'_> {
+        self.indirect(id).start()
+    }
+
     /// Start writing a metadata stream.
     pub fn metadata<'a>(&'a mut self, id: Ref, bytes: &'a [u8]) -> Metadata<'a> {
         Metadata::start(self.stream(id, bytes))

--- a/src/color.rs
+++ b/src/color.rs
@@ -181,7 +181,7 @@ impl<'a> IccProfile<'a> {
     /// The number of components in the color space.
     /// Shall be 1, 3, or 4.
     pub fn n(&mut self, n: i32) -> &mut Self {
-        assert!(n == 1 || n == 3 || n == 4, "n must be 1, 3, or 4, but is {}", n);
+        assert!(n == 1 || n == 3 || n == 4, "n must be 1, 3, or 4, but is {n}");
         self.pair(Name(b"N"), n);
         self
     }

--- a/src/content.rs
+++ b/src/content.rs
@@ -1031,8 +1031,8 @@ impl<'a> Artifact<'a> {
         self
     }
 
-    /// Write the `/Subtype` entry to set the subtype of pagination artifacts.
-    /// Specific to artifacts. PDF 1.7+.
+    /// Write the `/Subtype` entry to set the subtype of pagination or inline
+    /// artifacts. Specific to artifacts. PDF 1.7+.
     #[inline]
     pub fn subtype(&mut self, subtype: ArtifactSubtype) -> &mut Self {
         self.pair(Name(b"Subtype"), subtype.to_name());
@@ -1076,6 +1076,8 @@ pub enum ArtifactType {
     Page,
     /// Background image artifacts. PDF 1.7+.
     Background,
+    /// Artefacts related to inline content, such as line numbers or redactions. PDF 2.0+.
+    Inline,
 }
 
 impl ArtifactType {
@@ -1086,6 +1088,7 @@ impl ArtifactType {
             Self::Layout => Name(b"Layout"),
             Self::Page => Name(b"Page"),
             Self::Background => Name(b"Background"),
+            Self::Inline => Name(b"Inline"),
         }
     }
 }
@@ -1099,6 +1102,14 @@ pub enum ArtifactSubtype<'a> {
     Footer,
     /// Background watermarks.
     Watermark,
+    /// Page numbers. PDF 2.0+
+    PageNumber,
+    /// Bates numbering. PDF 2.0+
+    Bates,
+    /// Line numbers. PDF 2.0+
+    LineNumber,
+    /// Redactions. PDF 2.0+
+    Redaction,
     /// Custom subtype named according to ISO 32000-1:2008 Annex E.
     Custom(Name<'a>),
 }
@@ -1110,6 +1121,10 @@ impl<'a> ArtifactSubtype<'a> {
             Self::Header => Name(b"Header"),
             Self::Footer => Name(b"Footer"),
             Self::Watermark => Name(b"Watermark"),
+            Self::PageNumber => Name(b"PageNum"),
+            Self::Bates => Name(b"Bates"),
+            Self::LineNumber => Name(b"LineNum"),
+            Self::Redaction => Name(b"Redaction"),
             Self::Custom(name) => name,
         }
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -160,7 +160,7 @@ impl EmbeddingParams<'_> {
 deref!('a, EmbeddingParams<'a> => Dict<'a>, dict);
 
 /// How an embedded file relates to the PDF document it is embedded in.
-/// PDF/A-3 and PDF/A-4f.
+/// PDF 1.7 with PDF/A-3, PDF 2.0+ (including PDF/A-4f).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum AssociationKind {
     /// The PDF document was created from this source file.
@@ -171,6 +171,12 @@ pub enum AssociationKind {
     Alternative,
     /// Additional resources for this document.
     Supplement,
+    /// An encrypted file. PDF 2.0+.
+    EncryptedPayload,
+    /// Data associated with the `AcroForm`. PDF 2.0+.
+    FormData,
+    /// A machine-readable schema. PDF 2.0+.
+    Schema,
     /// There is no clear relationship or it is not known.
     Unspecified,
 }
@@ -182,6 +188,9 @@ impl AssociationKind {
             Self::Data => Name(b"Data"),
             Self::Alternative => Name(b"Alternative"),
             Self::Supplement => Name(b"Supplement"),
+            Self::EncryptedPayload => Name(b"EncryptedPayload"),
+            Self::FormData => Name(b"FormData"),
+            Self::Schema => Name(b"Schema"),
             Self::Unspecified => Name(b"Unspecified"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,8 @@ pub mod types {
     pub use structure::{
         BlockLevelRoleSubtype, Direction, InlineLevelRoleSubtype,
         InlineLevelRoleSubtype2, NumberingStyle, OutlineItemFlags, PageLayout, PageMode,
-        PhoneticAlphabet, StructRole, StructRole2, StructRoleType, StructRoleType2,
-        TabOrder, TrappingStatus,
+        PhoneticAlphabet, RoleMapOpts, StructRole, StructRole2, StructRole2Compat,
+        StructRoleType, StructRoleType2, TabOrder, TrappingStatus,
     };
     pub use transitions::{TransitionAngle, TransitionStyle};
     pub use xobject::SMaskInData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ impl Pdf {
                 written += 1;
             }
 
-            write!(buf.inner, "{:010} 00000 n\r\n", offset).unwrap();
+            write!(buf.inner, "{offset:010} 00000 n\r\n").unwrap();
             written += 1;
         }
 
@@ -366,7 +366,7 @@ impl Pdf {
 
         // Write where the cross-reference table starts.
         buf.extend(b"\nstartxref\n");
-        write!(buf.inner, "{}", xref_offset).unwrap();
+        write!(buf.inner, "{xref_offset}").unwrap();
 
         // Write the end of file marker.
         buf.extend(b"\n%%EOF");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,9 @@ pub mod writers {
     pub use renditions::{MediaClip, MediaPermissions, MediaPlayParams, Rendition};
     pub use structure::{
         Catalog, ClassMap, Destination, DeveloperExtension, DocumentInfo, MarkInfo,
-        MarkedRef, Metadata, Names, ObjectRef, Outline, OutlineItem, Page, PageLabel,
-        Pages, RoleMap, StructChildren, StructElement, StructTreeRoot, ViewerPreferences,
+        MarkedRef, Metadata, Names, Namespace, NamespaceRoleMap, ObjectRef, Outline,
+        OutlineItem, Page, PageLabel, Pages, RoleMap, StructChildren, StructElement,
+        StructTreeRoot, ViewerPreferences,
     };
     pub use transitions::Transition;
     pub use xobject::{FormXObject, Group, ImageXObject, Reference};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,9 @@ pub mod types {
     pub use object::Predictor;
     pub use renditions::{MediaClipType, RenditionType, TempFileType};
     pub use structure::{
-        Direction, NumberingStyle, OutlineItemFlags, PageLayout, PageMode, StructRole,
+        BlockLevelRoleSubtype, Direction, InlineLevelRoleSubtype,
+        InlineLevelRoleSubtype2, NumberingStyle, OutlineItemFlags, PageLayout, PageMode,
+        PhoneticAlphabet, StructRole, StructRole2, StructRoleType, StructRoleType2,
         TabOrder, TrappingStatus,
     };
     pub use transitions::{TransitionAngle, TransitionStyle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ pub mod writers {
         IconFit,
     };
     pub use attributes::{
-        Attributes, FieldAttributes, LayoutAttributes, ListAttributes, TableAttributes,
-        UserProperty,
+        ArtifactAttributes, Attributes, FieldAttributes, LayoutAttributes,
+        ListAttributes, TableAttributes, UserProperty,
     };
     pub use color::{
         ColorSpace, DeviceN, DeviceNAttrs, DeviceNMixingHints, DeviceNProcess,
@@ -157,8 +157,9 @@ pub mod types {
     };
     pub use attributes::{
         AttributeOwner, BlockAlign, FieldRole, FieldState, InlineAlign,
-        LayoutBorderStyle, LineHeight, ListNumbering, Placement, RubyAlign, RubyPosition,
-        TableHeaderScope, TextAlign, TextDecorationType, WritingMode,
+        LayoutBorderStyle, LayoutTextPosition, LineHeight, ListNumbering, Placement,
+        RubyAlign, RubyPosition, TableHeaderScope, TextAlign, TextDecorationType,
+        WritingMode,
     };
     pub use color::{
         DeviceNSubtype, FunctionShadingType, OutputIntentSubtype, PaintType, TilingType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ pub mod writers {
         IconFit,
     };
     pub use attributes::{
-        ArtifactAttributes, Attributes, FieldAttributes, LayoutAttributes,
-        ListAttributes, TableAttributes, UserProperty,
+        ArtifactAttributes, Attributes, FENoteAttributes, FieldAttributes,
+        LayoutAttributes, ListAttributes, TableAttributes, UserProperty,
     };
     pub use color::{
         ColorSpace, DeviceN, DeviceNAttrs, DeviceNMixingHints, DeviceNProcess,
@@ -158,9 +158,9 @@ pub mod types {
     };
     pub use attributes::{
         AttributeOwner, BlockAlign, FieldRole, FieldState, InlineAlign,
-        LayoutBorderStyle, LayoutTextPosition, LineHeight, ListNumbering, Placement,
-        RubyAlign, RubyPosition, TableHeaderScope, TextAlign, TextDecorationType,
-        WritingMode,
+        LayoutBorderStyle, LayoutTextPosition, LineHeight, ListNumbering, NoteType,
+        Placement, RubyAlign, RubyPosition, TableHeaderScope, TextAlign,
+        TextDecorationType, WritingMode,
     };
     pub use color::{
         DeviceNSubtype, FunctionShadingType, OutputIntentSubtype, PaintType, TilingType,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -94,7 +94,7 @@ impl Catalog<'_> {
     /// Write the `/Version` attribute to override the PDF version stated in the
     /// header. PDF 1.4+.
     pub fn version(&mut self, major: u8, minor: u8) -> &mut Self {
-        self.pair(Name(b"Version"), Name(format!("{}.{}", major, minor).as_bytes()));
+        self.pair(Name(b"Version"), Name(format!("{major}.{minor}").as_bytes()));
         self
     }
 
@@ -240,7 +240,7 @@ impl DeveloperExtension<'_> {
     /// Write the `/BaseVersion` attribute to specify the version of PDF this
     /// extension is based on. Required.
     pub fn base_version(&mut self, major: u8, minor: u8) -> &mut Self {
-        self.pair(Name(b"BaseVersion"), Name(format!("{}.{}", major, minor).as_bytes()));
+        self.pair(Name(b"BaseVersion"), Name(format!("{major}.{minor}").as_bytes()));
         self
     }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1116,22 +1116,21 @@ pub enum StructRole2 {
     Strong,
     /// A link.
     Link,
-    /// An association between an annotation and the content it belongs to. PDF
-    /// 1.5+
+    /// An association between an annotation and the content it belongs to.
     Annot,
     /// Form widget.
     Form,
-    /// Ruby annotation for CJK text. PDF 1.5+
+    /// Ruby annotation for CJK text.
     Ruby,
-    /// Base text of a Ruby annotation. PDF 1.5+
+    /// Base text of a Ruby annotation.
     RB,
-    /// Annotation text of a Ruby annotation. PDF 1.5+
+    /// Annotation text of a Ruby annotation.
     RT,
-    /// Warichu annotation for CJK text. PDF 1.5+
+    /// Warichu annotation for CJK text.
     Warichu,
-    /// Text of a Warichu annotation. PDF 1.5+
+    /// Text of a Warichu annotation.
     WT,
-    /// Punctuation of a Warichu annotation. PDF 1.5+
+    /// Punctuation of a Warichu annotation.
     WP,
     /// A list.
     L,
@@ -1214,125 +1213,88 @@ impl StructRole2 {
         }
     }
 
-    /// Return the corresponding PDF 1.7 [`StructRole`] for this role or `None`.
-    pub fn into_pdf_1_7(self) -> Option<StructRole> {
+    /// How the type should be represented in PDF 1.7.
+    ///
+    /// The `opts` parameter allows to control how certain roles are represented
+    /// in PDF 1.7. You can also use its default constructor.
+    pub fn compatibility_1_7(self, opts: RoleMapOpts) -> StructRole2Compat {
         match self {
-            Self::Document => Some(StructRole::Document),
-            Self::DocumentFragment => None,
-            Self::Part => Some(StructRole::Part),
-            Self::Sect => Some(StructRole::Sect),
-            Self::Div => Some(StructRole::Div),
-            Self::Aside => None,
-            Self::NonStruct => Some(StructRole::NonStruct),
-            Self::P => Some(StructRole::P),
-            Self::Heading(n) if n.get() == 1 => Some(StructRole::H1),
-            Self::Heading(n) if n.get() == 2 => Some(StructRole::H2),
-            Self::Heading(n) if n.get() == 3 => Some(StructRole::H3),
-            Self::Heading(n) if n.get() == 4 => Some(StructRole::H4),
-            Self::Heading(n) if n.get() == 5 => Some(StructRole::H5),
-            Self::Heading(n) if n.get() == 6 => Some(StructRole::H6),
-            Self::Heading(_) => None,
-            Self::StructuredHeading => None,
-            Self::Title => None,
-            Self::FENote => None,
-            Self::Sub => None,
-            Self::Lbl => Some(StructRole::Lbl),
-            Self::Span => Some(StructRole::Span),
-            Self::Em => None,
-            Self::Strong => None,
-            Self::Link => Some(StructRole::Link),
-            Self::Annot => Some(StructRole::Annot),
-            Self::Form => Some(StructRole::Form),
-            Self::Ruby => Some(StructRole::Ruby),
-            Self::RB => Some(StructRole::RB),
-            Self::RT => Some(StructRole::RT),
-            Self::Warichu => Some(StructRole::Warichu),
-            Self::WT => Some(StructRole::WT),
-            Self::WP => Some(StructRole::WP),
-            Self::L => Some(StructRole::L),
-            Self::LI => Some(StructRole::LI),
-            Self::LBody => Some(StructRole::LBody),
-            Self::Table => Some(StructRole::Table),
-            Self::TR => Some(StructRole::TR),
-            Self::TH => Some(StructRole::TH),
-            Self::TD => Some(StructRole::TD),
-            Self::THead => Some(StructRole::THead),
-            Self::TBody => Some(StructRole::TBody),
-            Self::TFoot => Some(StructRole::TFoot),
-            Self::Caption => Some(StructRole::Caption),
-            Self::Figure => Some(StructRole::Figure),
-            Self::Formula => Some(StructRole::Formula),
-            Self::Artifact => None,
-        }
-    }
-
-    /// Return the closest equivalent role in the PDF 1.7 namespace.
-    ///
-    /// Returns `None` if the role exactly matches a PDF 1.7 role (see
-    /// [`Self::into_pdf_1_7`]).
-    ///
-    /// There are three parameters governing the role mapping:
-    ///
-    /// - `map_hn_to_h6`: Are headings with levels higher than 6 are mapped to
-    ///   [`StructRole::H6`] (`true`) or [`StructRole::P`] (`false`)
-    /// - `map_title_to_h1`: Is the `Title` role mapped to [`StructRole::H1`]
-    ///   (`true`) or to [`StructRole::P`] (`false`)
-    /// - `map_sub_to_span`: Is the `Sub` role mapped to [`StructRole::Span`]
-    ///   (`true`) or to [`StructRole::Div`] (`false`)
-    pub fn role_mapped_1_7(
-        self,
-        map_hn_to_h6: bool,
-        map_title_to_h1: bool,
-        map_sub_to_span: bool,
-    ) -> Option<StructRole> {
-        match self {
-            Self::Document => None,
-            Self::DocumentFragment => Some(StructRole::Div),
-            Self::Part => None,
-            Self::Sect => None,
-            Self::Div => None,
-            Self::Aside => Some(StructRole::Div),
-            Self::NonStruct => None,
-            Self::P => None,
-            Self::Heading(n) if (1u16..=6).contains(&n.get()) => None,
-            Self::Heading(_) => {
-                Some(if map_hn_to_h6 { StructRole::H6 } else { StructRole::P })
+            Self::Document => StructRole2Compat::Compatible(StructRole::Document),
+            Self::DocumentFragment => StructRole2Compat::RoleMapping(StructRole::Div),
+            Self::Part => StructRole2Compat::Compatible(StructRole::Part),
+            Self::Sect => StructRole2Compat::Compatible(StructRole::Sect),
+            Self::Div => StructRole2Compat::Compatible(StructRole::Div),
+            Self::Aside => StructRole2Compat::RoleMapping(StructRole::Div),
+            Self::NonStruct => StructRole2Compat::Compatible(StructRole::NonStruct),
+            Self::P => StructRole2Compat::Compatible(StructRole::P),
+            Self::Heading(n) if n.get() == 1 => {
+                StructRole2Compat::Compatible(StructRole::H1)
             }
-            Self::StructuredHeading => Some(StructRole::P),
-            Self::Title => {
-                Some(if map_title_to_h1 { StructRole::H1 } else { StructRole::P })
+            Self::Heading(n) if n.get() == 2 => {
+                StructRole2Compat::Compatible(StructRole::H2)
             }
-            Self::FENote => Some(StructRole::Note),
-            Self::Sub => {
-                Some(if map_sub_to_span { StructRole::Span } else { StructRole::Div })
+            Self::Heading(n) if n.get() == 3 => {
+                StructRole2Compat::Compatible(StructRole::H3)
             }
-            Self::Lbl => None,
-            Self::Span => None,
-            Self::Em => Some(StructRole::Span),
-            Self::Strong => Some(StructRole::Span),
-            Self::Link => None,
-            Self::Annot => None,
-            Self::Form => None,
-            Self::Ruby => None,
-            Self::RB => None,
-            Self::RT => None,
-            Self::Warichu => None,
-            Self::WT => None,
-            Self::WP => None,
-            Self::L => None,
-            Self::LI => None,
-            Self::LBody => None,
-            Self::Table => None,
-            Self::TR => None,
-            Self::TH => None,
-            Self::TD => None,
-            Self::THead => None,
-            Self::TBody => None,
-            Self::TFoot => None,
-            Self::Caption => None,
-            Self::Figure => None,
-            Self::Formula => None,
-            Self::Artifact => Some(StructRole::Private),
+            Self::Heading(n) if n.get() == 4 => {
+                StructRole2Compat::Compatible(StructRole::H4)
+            }
+            Self::Heading(n) if n.get() == 5 => {
+                StructRole2Compat::Compatible(StructRole::H5)
+            }
+            Self::Heading(n) if n.get() == 6 => {
+                StructRole2Compat::Compatible(StructRole::H6)
+            }
+            Self::Heading(_) => StructRole2Compat::RoleMapping(
+                if opts.contains(RoleMapOpts::map_hn_to_h6) {
+                    StructRole::H6
+                } else {
+                    StructRole::P
+                },
+            ),
+            Self::StructuredHeading => StructRole2Compat::RoleMapping(StructRole::P),
+            Self::Title => StructRole2Compat::RoleMapping(
+                if opts.contains(RoleMapOpts::map_title_to_h1) {
+                    StructRole::H1
+                } else {
+                    StructRole::P
+                },
+            ),
+            Self::FENote => StructRole2Compat::RoleMapping(StructRole::Note),
+            Self::Sub => StructRole2Compat::RoleMapping(
+                if opts.contains(RoleMapOpts::map_sub_to_span) {
+                    StructRole::Span
+                } else {
+                    StructRole::Div
+                },
+            ),
+            Self::Lbl => StructRole2Compat::Compatible(StructRole::Lbl),
+            Self::Span => StructRole2Compat::Compatible(StructRole::Span),
+            Self::Em => StructRole2Compat::RoleMapping(StructRole::Span),
+            Self::Strong => StructRole2Compat::RoleMapping(StructRole::Span),
+            Self::Link => StructRole2Compat::Compatible(StructRole::Link),
+            Self::Annot => StructRole2Compat::Compatible(StructRole::Annot),
+            Self::Form => StructRole2Compat::Compatible(StructRole::Form),
+            Self::Ruby => StructRole2Compat::Compatible(StructRole::Ruby),
+            Self::RB => StructRole2Compat::Compatible(StructRole::RB),
+            Self::RT => StructRole2Compat::Compatible(StructRole::RT),
+            Self::Warichu => StructRole2Compat::Compatible(StructRole::Warichu),
+            Self::WT => StructRole2Compat::Compatible(StructRole::WT),
+            Self::WP => StructRole2Compat::Compatible(StructRole::WP),
+            Self::L => StructRole2Compat::Compatible(StructRole::L),
+            Self::LI => StructRole2Compat::Compatible(StructRole::LI),
+            Self::LBody => StructRole2Compat::Compatible(StructRole::LBody),
+            Self::Table => StructRole2Compat::Compatible(StructRole::Table),
+            Self::TR => StructRole2Compat::Compatible(StructRole::TR),
+            Self::TH => StructRole2Compat::Compatible(StructRole::TH),
+            Self::TD => StructRole2Compat::Compatible(StructRole::TD),
+            Self::THead => StructRole2Compat::Compatible(StructRole::THead),
+            Self::TBody => StructRole2Compat::Compatible(StructRole::TBody),
+            Self::TFoot => StructRole2Compat::Compatible(StructRole::TFoot),
+            Self::Caption => StructRole2Compat::Compatible(StructRole::Caption),
+            Self::Figure => StructRole2Compat::Compatible(StructRole::Figure),
+            Self::Formula => StructRole2Compat::Compatible(StructRole::Formula),
+            Self::Artifact => StructRole2Compat::RoleMapping(StructRole::Private),
         }
     }
 
@@ -1377,11 +1339,75 @@ impl StructRole2 {
     }
 }
 
+bitflags::bitflags! {
+    /// Options for mapping PDF 2.0 [`StructRole2`] to PDF 1.7 [`StructRole`].
+    pub struct RoleMapOpts: u8 {
+        /// Whether to map headings with levels higher than 6 to [`StructRole::H6`]
+        /// (`true`) or [`StructRole::P`] (`false`).
+        const map_hn_to_h6 = 1 << 0;
+        /// Whether to map the `Title` role to [`StructRole::H1`] (`true`) or
+        /// [`StructRole::P`] (`false`).
+        const map_title_to_h1 = 1 << 1;
+        /// Whether to map the `Sub` role to [`StructRole::Span`] (`true`) or
+        /// [`StructRole::Div`] (`false`).
+        const map_sub_to_span = 1 << 2;
+    }
+}
+
+impl Default for RoleMapOpts {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// How a particular PDF 2.0 [`StructRole2`] can be represented in PDF 1.7.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum StructRole2Compat {
+    /// The role is a direct match with this PDF 1.7 role.
+    Compatible(StructRole),
+    /// The has no direct match with a PDF 1.7 role, but can be mapped to
+    /// a PDF 1.7 role with a similar meaning.
+    RoleMapping(StructRole),
+}
+
+impl StructRole2Compat {
+    /// Return the corresponding PDF 1.7 [`StructRole`] for this role or `None`
+    /// if there is no exact match.
+    pub fn into_pdf_1_7(self) -> Option<StructRole> {
+        match self {
+            Self::Compatible(role) => Some(role),
+            Self::RoleMapping(_) => None,
+        }
+    }
+
+    /// Return the closest equivalent role in the PDF 1.7 namespace.
+    ///
+    /// Returns `None` if the role exactly matches a PDF 1.7 role (see
+    /// [`Self::into_pdf_1_7`]).
+    pub fn role_mapped_1_7(self) -> Option<StructRole> {
+        match self {
+            Self::Compatible(_) => None,
+            Self::RoleMapping(role) => Some(role),
+        }
+    }
+
+    /// Return the inner role.
+    pub fn role(self) -> StructRole {
+        match self {
+            Self::Compatible(role) => role,
+            Self::RoleMapping(role) => role,
+        }
+    }
+}
+
 impl TryFrom<StructRole2> for StructRole {
     type Error = ();
 
     fn try_from(value: StructRole2) -> Result<Self, Self::Error> {
-        value.into_pdf_1_7().ok_or(())
+        value
+            .compatibility_1_7(RoleMapOpts::default())
+            .into_pdf_1_7()
+            .ok_or(())
     }
 }
 


### PR DESCRIPTION
This PR adds support for various features introduced in PDF 2.0 around structure trees and tagged PDF:

- It adds the PDF 2.0 mechanism for namespaced types and attributes as well as the types from the PDF 2.0 namespace
- It adds new attributes introduced in PDF 2.0 for existing default attribute owners
- It adds new attribute values for existing attributes. In particular, `ListNumbering` has gained attributes for specifying numbered, unordered, or definition lists without specifying the bullet used.
- It adds the new attribute owner `Artifact` from PDF 2.0 and `FENote` from PDF/UA-2
- It adds more types for Associated Files introduced in PDF 2.0
- It adds keys in the structure tree root and element dictionaries around pronunciation and related elements
- `pdf_writer::writers::Attributes::owner` now allows writing either the old name for CSS attribute owners or the new name introduced in `ISO 32000-2:2020`. This is accomplished through a new argument, which is a breaking change.
- `pdf_writer::writers::FieldAttributes::checked` now allows writing either the old lower case name for the key or the new name introduced in `ISO 32000-2:2020`. This is accomplished through a new argument, which is a breaking change.
- Likewise, some enums not marked as `non_exhaustive` gained new variants, which is a breaking change.