### PR TITLE
Write correct `Namespace` identifier and `RoleMapNS` entries

### DIFF
--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1523,7 +1523,7 @@ writer!(Namespace: |obj| {
 impl Namespace<'_> {
     /// Write the `/NS` attribute to specify the identifier (URI) of the namespace.
     pub fn ns(&mut self, identifier: TextStr) -> &mut Self {
-        self.dict.pair(Name(b"Name"), identifier);
+        self.dict.pair(Name(b"NS"), identifier);
         self
     }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -1585,10 +1585,10 @@ impl NamespaceRoleMap<'_> {
     /// namespace referenced by the namespace dictionary the value of the
     /// `ns_ref` parameter points to.
     pub fn to_namespace(&mut self, name: Name, role: Name, ns_ref: Ref) -> &mut Self {
-        let mut dict = self.dict.insert(name).dict();
-        dict.pair(Name(b"Role"), role);
-        dict.pair(Name(b"NS"), ns_ref);
-        dict.finish();
+        let mut array = self.dict.insert(name).array();
+        array.item(role);
+        array.item(ns_ref);
+        array.finish();
         self
     }
 
@@ -1604,11 +1604,7 @@ impl NamespaceRoleMap<'_> {
         role: StructRole2,
         pdf_2_ns: Ref,
     ) -> &mut Self {
-        let mut dict = self.dict.insert(name).dict();
-        dict.pair(Name(b"Role"), role.to_name(&mut [0; 6]));
-        dict.pair(Name(b"NS"), pdf_2_ns);
-        dict.finish();
-        self
+        self.to_namespace(name, role.to_name(&mut [0; 6]), pdf_2_ns)
     }
 }
 


### PR DESCRIPTION
Looking at the spec, the entries of the `RoleMapNS` should either be names, or arrays instead of dicts:
> ... The corresponding value for each of these keys shall
either be a single name identifying a structure element type in the default
standard structure namespace or an array where the first value shall be a
structure element type name in a target namespace with the second value being
an indirect reference to the target namespace dictionary

And the namespace identifier should be written under the `NS` key instead of `Name`.