### PR TITLE
Add a `reset` API

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -35,6 +35,12 @@ impl Buf {
     pub fn limits(&self) -> &Limits {
         &self.limits
     }
+    
+    /// Reset the buffer.
+    pub fn reset(&mut self) {
+        self.inner.clear();
+        self.limits = Limits::new();
+    }
 
     #[inline]
     pub(crate) fn push_val<T: Primitive>(&mut self, value: T) {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -97,6 +97,12 @@ impl Chunk {
     pub fn refs(&self) -> impl ExactSizeIterator<Item = Ref> + '_ {
         self.offsets.iter().map(|&(id, _)| id)
     }
+    
+    /// Reset the chunk.
+    pub fn reset(&mut self) {
+        self.buf.reset();
+        self.offsets.clear();
+    }
 
     /// Returns the limits of data written into the chunk.
     pub fn limits(&self) -> &Limits {


### PR DESCRIPTION
This allows users to reset chunks, making it possible to reuse the inner allocations. While I don't have a specific need for this now, I think it could come in handy in the future.

I'm not sure if the `reset` method should take `Settings` as well so that they can be changed if desired. Or maybe a `reset_with_settings` method?