### PR TITLE
Explorations for object streams

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -33,8 +33,33 @@ impl Default for Settings {
 #[derive(Clone)]
 pub struct Chunk {
     pub(crate) buf: Buf,
-    pub(crate) offsets: Vec<(Ref, usize)>,
+    pub(crate) entries: Vec<ChunkEntry>,
     pub(crate) settings: Settings,
+    pub(crate) has_streams: bool,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub(crate) enum ChunkEntry {
+    Normal { id: Ref, offset: usize },
+    Compressed { id: Ref, object_stream: Ref, index: u32 },
+}
+
+impl ChunkEntry {
+    pub(crate) fn id(self) -> Ref {
+        match self {
+            Self::Normal { id, .. } | Self::Compressed { id, .. } => id,
+        }
+    }
+}
+
+/// An indirect object stored in a [`Chunk`].
+pub(crate) struct IndirectObject<'a> {
+    /// The reference of the indirect object.
+    pub(crate) id: Ref,
+    /// The generation number of the indirect object.
+    pub(crate) generation: i32,
+    /// The body of the indirect object, without the surrounding object header and footer.
+    pub(crate) body: &'a [u8],
 }
 
 impl Chunk {
@@ -62,8 +87,9 @@ impl Chunk {
     pub fn with_settings_and_capacity(settings: Settings, capacity: usize) -> Self {
         Self {
             buf: Buf::with_capacity(capacity),
-            offsets: vec![],
+            entries: vec![],
             settings,
+            has_streams: false,
         }
     }
 
@@ -88,14 +114,55 @@ impl Chunk {
     pub fn extend(&mut self, other: &Chunk) {
         let base = self.len();
         self.buf.extend_buf(&other.buf);
-        self.offsets
-            .extend(other.offsets.iter().map(|&(id, offset)| (id, base + offset)));
+        self.entries.extend(other.entries.iter().map(|&entry| match entry {
+            ChunkEntry::Normal { id, offset } => {
+                ChunkEntry::Normal { id, offset: base + offset }
+            }
+            ChunkEntry::Compressed { id, object_stream, index } => {
+                ChunkEntry::Compressed { id, object_stream, index }
+            }
+        }));
+        self.has_streams |= other.has_streams;
     }
 
     /// An iterator over the references of the top-level objects
     /// of the chunk, in the order they appear in the chunk.
     pub fn refs(&self) -> impl ExactSizeIterator<Item = Ref> + '_ {
-        self.offsets.iter().map(|&(id, _)| id)
+        self.entries.iter().map(|&entry| entry.id())
+    }
+
+    /// An iterator over the top-level indirect objects in the chunk.
+    pub(crate) fn indirect_objects(
+        &self,
+    ) -> impl Iterator<Item = IndirectObject<'_>> + '_ {
+        self.entries.iter().copied().enumerate().filter_map(|(idx, entry)| {
+            let ChunkEntry::Normal { id, offset } = entry else {
+                return None;
+            };
+
+            let end = self.entries[idx + 1..]
+                .iter()
+                .find_map(|&entry| match entry {
+                    ChunkEntry::Normal { offset, .. } => Some(offset),
+                    ChunkEntry::Compressed { .. } => None,
+                })
+                .unwrap_or(self.buf.len());
+            let slice = &self.buf[offset..end];
+            let (generation, body) = crate::renumber::extract_object(slice)?;
+            Some(IndirectObject { id, generation, body })
+        })
+    }
+
+    /// Whether the chunk contains compressed cross-reference entries.
+    pub fn has_compressed_xref_entries(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|entry| matches!(entry, ChunkEntry::Compressed { .. }))
+    }
+
+    /// Whether the chunk contains stream objects.
+    pub fn has_streams(&self) -> bool {
+        self.has_streams
     }
 
     /// Returns the limits of data written into the chunk.
@@ -167,6 +234,8 @@ impl Chunk {
     /// for them will probably not make sense, so it's up to you to either not
     /// have dangling references or handle them in a way that makes sense for
     /// your use case.
+    ///
+    /// Panics if this chunk contains objects stored in object streams.
     pub fn renumber<F>(&self, mapping: F) -> Chunk
     where
         F: FnMut(Ref) -> Ref,
@@ -178,6 +247,8 @@ impl Chunk {
 
     /// Same as [`renumber`](Self::renumber), but writes the results into an
     /// existing `target` chunk instead of creating a new chunk.
+    ///
+    /// Panics if this chunk contains objects stored in object streams.
     pub fn renumber_into<F>(&self, target: &mut Chunk, mut mapping: F)
     where
         F: FnMut(Ref) -> Ref,
@@ -191,7 +262,7 @@ impl Chunk {
 impl Chunk {
     /// Start writing an indirectly referenceable object.
     pub fn indirect(&mut self, id: Ref) -> Obj<'_> {
-        self.offsets.push((id, self.buf.len()));
+        self.entries.push(ChunkEntry::Normal { id, offset: self.buf.len() });
         Obj::indirect(&mut self.buf, id, self.settings)
     }
 
@@ -245,6 +316,7 @@ impl Chunk {
     ///
     /// Panics if the stream length exceeds `i32::MAX`.
     pub fn stream<'a>(&'a mut self, id: Ref, data: &'a [u8]) -> Stream<'a> {
+        self.has_streams = true;
         Stream::start(self.indirect(id), data)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod font;
 mod forms;
 mod functions;
 mod object;
+mod object_stream;
 mod renditions;
 mod renumber;
 mod structure;
@@ -198,11 +199,13 @@ pub use self::object::{
     Rect, Ref, Rewrite, Str, Stream, TextStr, TextStrLike, TextStrWithLang, TypedArray,
     TypedDict, Writer,
 };
+pub use self::object_stream::{ObjectStreamBuilder, ObjectStreamFilter, ObjectStreamJob};
 
 use std::fmt::{self, Debug, Formatter};
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
 
+use self::chunk::ChunkEntry;
 use self::writers::*;
 
 /// A builder for a PDF file.
@@ -305,12 +308,18 @@ impl Pdf {
     ///
     /// Panics if any indirect reference id was used twice.
     pub fn finish(self) -> Vec<u8> {
-        let Chunk { mut buf, offsets, settings } = self.chunk;
+        let Chunk { mut buf, entries, settings, .. } = self.chunk;
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| matches!(entry, ChunkEntry::Compressed { .. })),
+            "plain xref tables cannot reference compressed objects"
+        );
         let trailer_data = self.trailer_data;
         let xref_offset = buf.len();
 
         let mut writer = PlainXRefWriter::new(&mut buf);
-        let xref_len = write_offsets(offsets, &mut writer);
+        let xref_len = write_offsets(entries, &mut writer);
 
         // Write the trailer dictionary.
         buf.extend(b"trailer\n");
@@ -342,6 +351,23 @@ impl Pdf {
         self.finish_with_xref_stream_inner(xref_id, |buf| (buf, None))
     }
 
+    /// Write the cross-reference stream using the next available reference id.
+    pub fn finish_with_xref_stream_auto(self) -> Vec<u8> {
+        let max_ref = self
+            .chunk
+            .entries
+            .iter()
+            .flat_map(|entry| match *entry {
+                ChunkEntry::Normal { id, .. } => [id.get(), 0],
+                ChunkEntry::Compressed { id, object_stream, .. } => {
+                    [id.get(), object_stream.get()]
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        self.finish_with_xref_stream(Ref::new(max_ref + 1))
+    }
+
     /// Write the cross-reference stream and file trailer and return the
     /// underlying buffer.
     ///
@@ -367,16 +393,38 @@ impl Pdf {
         xref_id: Ref,
         filter: impl FnOnce(Vec<u8>) -> (Vec<u8>, Option<XRefFilter>),
     ) -> Vec<u8> {
-        let Chunk { mut buf, mut offsets, settings } = self.chunk;
+        let Chunk { mut buf, mut entries, settings, .. } = self.chunk;
         let trailer_data = self.trailer_data;
 
-        // Include the reference of the xref stream in the offsets as well!
+        // Include the reference of the xref stream in the entries as well!
         let xref_offset = buf.len();
-        offsets.push((xref_id, xref_offset));
-        let field_width = determine_field_width(xref_offset);
+        entries.push(ChunkEntry::Normal { id: xref_id, offset: xref_offset });
+        let offset_width = determine_field_width(
+            entries
+                .iter()
+                .map(|entry| match *entry {
+                    ChunkEntry::Normal { offset, .. } => offset,
+                    ChunkEntry::Compressed { object_stream, .. } => {
+                        object_stream.get() as usize
+                    }
+                })
+                .max()
+                .unwrap(),
+        );
+        let index_width = determine_field_width(
+            entries
+                .iter()
+                .filter_map(|entry| match *entry {
+                    ChunkEntry::Normal { .. } => None,
+                    ChunkEntry::Compressed { index, .. } => Some(index as usize),
+                })
+                .chain(std::iter::once(u16::MAX as usize))
+                .max()
+                .unwrap(),
+        );
 
-        let mut writer = XRefStreamWriter::new(field_width);
-        let xref_len = write_offsets(offsets, &mut writer);
+        let mut writer = XRefStreamWriter::new(offset_width, index_width);
+        let xref_len = write_offsets(entries, &mut writer);
 
         let (xref_data, filter) = filter(writer.buf);
 
@@ -406,8 +454,8 @@ impl Pdf {
             .insert(Name(b"W"))
             .array()
             .item(1)
-            .item(field_width as i32)
-            .item(2);
+            .item(offset_width as i32)
+            .item(index_width as i32);
 
         stream.finish();
 
@@ -434,18 +482,19 @@ fn finish_trailer(mut buf: Buf, xref_offset: usize, pad: &[u8]) -> Vec<u8> {
     buf.into_vec()
 }
 
-fn write_offsets(mut offsets: Vec<(Ref, usize)>, writer: &mut impl XRefWriter) -> i32 {
-    offsets.sort();
+fn write_offsets(mut entries: Vec<ChunkEntry>, writer: &mut impl XRefWriter) -> i32 {
+    entries.sort_by_key(|entry| entry.id());
 
-    let xref_len = 1 + offsets.last().map_or(0, |p| p.0.get());
+    let xref_len = 1 + entries.last().map_or(0, |entry| entry.id().get());
     writer.prologue(xref_len);
 
-    if offsets.is_empty() {
+    if entries.is_empty() {
         writer.write_free_entry(0, 65535);
     }
 
     let mut written = 0;
-    for (i, (object_id, offset)) in offsets.iter().enumerate() {
+    for (i, entry) in entries.iter().enumerate() {
+        let object_id = entry.id();
         if written > object_id.get() {
             panic!("duplicate indirect reference id: {}", object_id.get());
         }
@@ -456,7 +505,7 @@ fn write_offsets(mut offsets: Vec<(Ref, usize)>, writer: &mut impl XRefWriter) -
             let mut next = free_id + 1;
             if next == object_id.get() {
                 // Find next free id.
-                for (used_id, _) in &offsets[i..] {
+                for used_id in entries[i..].iter().map(|entry| entry.id()) {
                     if next < used_id.get() {
                         break;
                     } else {
@@ -470,7 +519,14 @@ fn write_offsets(mut offsets: Vec<(Ref, usize)>, writer: &mut impl XRefWriter) -
             written += 1;
         }
 
-        writer.write_occupied_entry(*offset, 0);
+        match *entry {
+            ChunkEntry::Normal { offset, .. } => {
+                writer.write_occupied_entry(offset, 0);
+            }
+            ChunkEntry::Compressed { object_stream, index, .. } => {
+                writer.write_compressed_entry(object_stream, index);
+            }
+        }
         written += 1;
     }
 
@@ -528,30 +584,31 @@ trait XRefWriter {
     fn prologue(&mut self, xref_len: i32);
     fn write_free_entry(&mut self, offset: usize, gen_number: u16);
     fn write_occupied_entry(&mut self, offset: usize, gen_number: u16);
+    fn write_compressed_entry(&mut self, object_stream: Ref, index: u32);
 }
 
 struct XRefStreamWriter {
     buf: Vec<u8>,
-    field_width: u32,
+    offset_width: u32,
+    index_width: u32,
 }
 
 impl XRefStreamWriter {
-    fn new(field_width: u32) -> Self {
-        Self { buf: Vec::new(), field_width }
+    fn new(offset_width: u32, index_width: u32) -> Self {
+        Self { buf: Vec::new(), offset_width, index_width }
     }
 }
 
 impl XRefStreamWriter {
-    fn write(&mut self, entry_type: u8, offset: usize, gen_number: u16) {
-        let offset_bytes = (offset as u64).to_be_bytes();
+    fn write_int(&mut self, value: u64, width: u32) {
+        let bytes = value.to_be_bytes();
+        self.buf.extend(bytes.iter().skip(bytes.len() - width as usize));
+    }
 
+    fn write(&mut self, entry_type: u8, field2: u64, field3: u64) {
         self.buf.push(entry_type);
-        self.buf.extend(
-            offset_bytes
-                .iter()
-                .skip(offset_bytes.len() - self.field_width as usize),
-        );
-        self.buf.extend_from_slice(&gen_number.to_be_bytes());
+        self.write_int(field2, self.offset_width);
+        self.write_int(field3, self.index_width);
     }
 }
 
@@ -559,11 +616,15 @@ impl XRefWriter for XRefStreamWriter {
     fn prologue(&mut self, _: i32) {}
 
     fn write_free_entry(&mut self, offset: usize, gen_number: u16) {
-        self.write(0, offset, gen_number);
+        self.write(0, offset as u64, gen_number as u64);
     }
 
     fn write_occupied_entry(&mut self, offset: usize, gen_number: u16) {
-        self.write(1, offset, gen_number);
+        self.write(1, offset as u64, gen_number as u64);
+    }
+
+    fn write_compressed_entry(&mut self, object_stream: Ref, index: u32) {
+        self.write(2, object_stream.get() as u64, index as u64);
     }
 }
 
@@ -591,6 +652,10 @@ impl<'a> XRefWriter for PlainXRefWriter<'a> {
     fn write_occupied_entry(&mut self, offset: usize, gen_number: u16) {
         write!(self.buf.inner, "{offset:010} {gen_number:05} n\r\n").unwrap();
     }
+
+    fn write_compressed_entry(&mut self, _: Ref, _: u32) {
+        unreachable!("plain xref tables cannot reference compressed objects");
+    }
 }
 
 fn determine_field_width(offset: usize) -> u32 {
@@ -605,8 +670,20 @@ mod tests {
     #[allow(unused)]
     pub fn print_chunk(chunk: &Chunk) {
         println!("========== Chunk ==========");
-        for &(id, offset) in &chunk.offsets {
-            println!("[{}]: {}", id.get(), offset);
+        for &entry in &chunk.entries {
+            match entry {
+                ChunkEntry::Normal { id, offset } => {
+                    println!("[{}]: {}", id.get(), offset);
+                }
+                ChunkEntry::Compressed { id, object_stream, index } => {
+                    println!(
+                        "[{}]: object stream {}, index {}",
+                        id.get(),
+                        object_stream.get(),
+                        index
+                    );
+                }
+            }
         }
         println!("---------------------------");
         print!("{}", String::from_utf8_lossy(&chunk.buf));
@@ -752,6 +829,28 @@ mod tests {
             b"endstream\nendobj\n",
             b"startxref\n70\n%%EOF",
         )
+    }
+
+    #[test]
+    fn test_xref_stream_compressed_entry() {
+        let mut w = Pdf::new();
+        let mut source = Chunk::new();
+        source.indirect(Ref::new(1)).primitive(1);
+
+        let mut builder = ObjectStreamBuilder::new(Settings::default(), 100);
+        let mut next_ref = || Ref::new(2);
+        let mut spawn = ObjectStreamJob::build;
+
+        builder.extend_with(&source, &mut next_ref, &mut spawn);
+        for chunk in builder.finish_with(&mut next_ref, &mut spawn) {
+            w.extend(&chunk);
+        }
+
+        let pdf = w.finish_with_xref_stream_auto();
+        assert!(pdf.windows(b"/W [1 1 2]".len()).any(|window| window == b"/W [1 1 2]"));
+        assert!(pdf
+            .windows(b"\x02\x02\x00\x00".len())
+            .any(|window| window == b"\x02\x02\x00\x00"));
     }
 
     #[test]

--- a/src/object_stream.rs
+++ b/src/object_stream.rs
@@ -1,0 +1,188 @@
+use std::io::Write;
+
+use crate::chunk::ChunkEntry;
+use crate::{Chunk, Filter, Limits, Name, Ref, Settings};
+
+#[derive(Clone)]
+struct PackedObject {
+    id: Ref,
+    body: Vec<u8>,
+}
+
+/// The filters used for an object stream.
+pub enum ObjectStreamFilter {
+    /// A single filter.
+    Single(Filter),
+    /// An array of filters.
+    Multiple(Vec<Filter>),
+}
+
+/// A batch of objects ready to be serialized as one object stream.
+pub struct ObjectStreamJob {
+    object_stream_ref: Ref,
+    objects: Vec<PackedObject>,
+    settings: Settings,
+    source_limits: Limits,
+}
+
+impl ObjectStreamJob {
+    /// Build the object stream chunk without applying a filter.
+    pub fn build(self) -> Chunk {
+        self.build_inner(|data| (data, None))
+    }
+
+    /// Build the object stream chunk and apply a filter to the stream data.
+    pub fn build_with_filter(
+        self,
+        filter: impl FnOnce(&[u8]) -> (Vec<u8>, ObjectStreamFilter),
+    ) -> Chunk {
+        self.build_inner(|data| {
+            let (filtered, filter) = filter(&data);
+            (filtered, Some(filter))
+        })
+    }
+
+    fn build_inner(
+        self,
+        filter: impl FnOnce(Vec<u8>) -> (Vec<u8>, Option<ObjectStreamFilter>),
+    ) -> Chunk {
+        let mut offsets = Vec::new();
+        let mut bodies = Vec::new();
+
+        for object in &self.objects {
+            offsets.push((object.id, bodies.len()));
+            bodies.extend_from_slice(&object.body);
+            bodies.push(b'\n');
+        }
+
+        let mut data = Vec::new();
+        for (id, offset) in &offsets {
+            write!(&mut data, "{} {} ", id.get(), offset).unwrap();
+        }
+
+        let first = data.len();
+        data.extend_from_slice(&bodies);
+
+        let (data, filter) = filter(data);
+
+        let mut chunk = Chunk::with_settings(self.settings);
+        chunk.merge_limits(&self.source_limits);
+        {
+            let mut stream = chunk.stream(self.object_stream_ref, &data);
+            stream
+                .pair(Name(b"Type"), Name(b"ObjStm"))
+                .pair(Name(b"N"), self.objects.len() as i32)
+                .pair(Name(b"First"), first as i32);
+
+            if let Some(filter) = filter {
+                match filter {
+                    ObjectStreamFilter::Single(filter) => {
+                        stream.filter(filter);
+                    }
+                    ObjectStreamFilter::Multiple(filters) => {
+                        let mut arr = stream.insert(Name(b"Filter")).array();
+
+                        for filter in filters {
+                            arr.item(filter.to_name());
+                        }
+                    }
+                }
+            }
+        }
+
+        for (index, object) in self.objects.into_iter().enumerate() {
+            chunk.entries.push(ChunkEntry::Compressed {
+                id: object.id,
+                object_stream: self.object_stream_ref,
+                index: index as u32,
+            });
+        }
+
+        chunk
+    }
+}
+
+/// Builds object stream jobs from chunks containing ordinary indirect objects.
+pub struct ObjectStreamBuilder<T> {
+    settings: Settings,
+    max_objects: usize,
+    pending: Vec<PackedObject>,
+    pending_limits: Limits,
+    streams: Vec<T>,
+}
+
+impl<T> ObjectStreamBuilder<T> {
+    /// Create a new object stream builder.
+    ///
+    /// `max_objects` controls how many objects are written into each object
+    /// stream and must be greater than zero.
+    pub fn new(settings: Settings, max_objects: usize) -> Self {
+        assert!(max_objects > 0, "object streams must contain at least one object");
+        Self {
+            settings,
+            max_objects,
+            pending: Vec::new(),
+            pending_limits: Limits::new(),
+            streams: Vec::new(),
+        }
+    }
+
+    /// Extend the builder with all objects from `chunk`.
+    ///
+    /// Panics if the chunk contains stream objects.
+    pub fn extend_with(
+        &mut self,
+        chunk: &Chunk,
+        next_ref: &mut impl FnMut() -> Ref,
+        spawn: &mut impl FnMut(ObjectStreamJob) -> T,
+    ) {
+        assert!(
+            !chunk.has_streams(),
+            "object streams can only contain non-stream objects"
+        );
+
+        for object in chunk.indirect_objects() {
+            // Objects written through the public API always have generation 0.
+            assert_eq!(
+                object.generation, 0,
+                "object streams can only contain generation 0 objects"
+            );
+
+            self.pending_limits.merge(chunk.limits());
+            self.pending
+                .push(PackedObject { id: object.id, body: object.body.to_vec() });
+
+            if self.pending.len() == self.max_objects {
+                self.flush(next_ref, spawn);
+            }
+        }
+    }
+
+    /// Finish the builder and return all spawned object streams.
+    pub fn finish_with(
+        mut self,
+        next_ref: &mut impl FnMut() -> Ref,
+        spawn: &mut impl FnMut(ObjectStreamJob) -> T,
+    ) -> Vec<T> {
+        self.flush(next_ref, spawn);
+        self.streams
+    }
+
+    fn flush(
+        &mut self,
+        next_ref: &mut impl FnMut() -> Ref,
+        spawn: &mut impl FnMut(ObjectStreamJob) -> T,
+    ) {
+        if self.pending.is_empty() {
+            return;
+        }
+
+        let job = ObjectStreamJob {
+            object_stream_ref: next_ref(),
+            objects: std::mem::take(&mut self.pending),
+            settings: self.settings,
+            source_limits: std::mem::replace(&mut self.pending_limits, Limits::new()),
+        };
+        self.streams.push(spawn(job));
+    }
+}

--- a/src/renumber.rs
+++ b/src/renumber.rs
@@ -1,3 +1,4 @@
+use crate::chunk::ChunkEntry;
 use crate::{Buf, Chunk, Ref};
 
 /// Renumbers a chunk of objects.
@@ -5,14 +6,26 @@ use crate::{Buf, Chunk, Ref};
 /// See [`Chunk::renumber`] for more details.
 pub fn renumber(source: &Chunk, target: &mut Chunk, mapping: &mut dyn FnMut(Ref) -> Ref) {
     target.buf.limits.merge(source.limits());
+    target.has_streams |= source.has_streams();
 
-    let mut iter = source.offsets.iter().copied().peekable();
+    let mut iter = source
+        .entries
+        .iter()
+        .filter_map(|entry| match *entry {
+            ChunkEntry::Normal { id, offset } => Some((id, offset)),
+            ChunkEntry::Compressed { .. } => {
+                panic!("chunks with object streams cannot be renumbered");
+            }
+        })
+        .peekable();
     while let Some((id, offset)) = iter.next() {
         let new = mapping(id);
         let end = iter.peek().map_or(source.buf.len(), |&(_, offset)| offset);
         let slice = &source.buf[offset..end];
         let Some((gen, slice)) = extract_object(slice) else { continue };
-        target.offsets.push((new, target.buf.len()));
+        target
+            .entries
+            .push(ChunkEntry::Normal { id: new, offset: target.buf.len() });
         target.buf.push_int(new.get());
         target.buf.push(b' ');
         target.buf.push_int(gen);
@@ -27,7 +40,7 @@ pub fn renumber(source: &Chunk, target: &mut Chunk, mapping: &mut dyn FnMut(Ref)
 }
 
 /// Extract the generation number and interior of an indirect object.
-fn extract_object(slice: &[u8]) -> Option<(i32, &[u8])> {
+pub(crate) fn extract_object(slice: &[u8]) -> Option<(i32, &[u8])> {
     let offset = memchr::memmem::find(slice, b"obj")?;
     let mut prefix = &slice[..offset];
     require_whitespace_rev(&mut prefix);
@@ -169,7 +182,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::{Name, Ref, TextStr};
+    use crate::{Name, ObjectStreamBuilder, ObjectStreamJob, Ref, Settings, TextStr};
 
     #[test]
     fn test_renumber() {
@@ -188,7 +201,8 @@ mod tests {
             .pair(Name(b"Unsafe"), TextStr("()(And (More) 17 0 R())"));
 
         // Manually write an untidy object.
-        c.offsets.push((Ref::new(8), c.buf.len()));
+        c.entries
+            .push(ChunkEntry::Normal { id: Ref::new(8), offset: c.buf.len() });
         c.buf.extend(b"8  3  obj\n<</Fmt false/Niceness(4 0\nR-)");
         c.buf.extend(b"/beginobj/endobj%4 0 R\n");
         c.buf.extend(b"/Me 8 3  R/Unknown 11 0  R/R[4  0\nR]>>%\n\nendobj");
@@ -240,5 +254,25 @@ mod tests {
             b"endstream",
             b"endobj\n\n"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "chunks with object streams cannot be renumbered")]
+    fn test_renumber_object_stream_panics() {
+        let mut source = Chunk::new();
+        source.indirect(Ref::new(1)).primitive(1);
+
+        let mut builder = ObjectStreamBuilder::new(Settings::default(), 100);
+        let mut next_ref = || Ref::new(2);
+        let mut spawn = ObjectStreamJob::build;
+
+        builder.extend_with(&source, &mut next_ref, &mut spawn);
+        let object_stream = builder
+            .finish_with(&mut next_ref, &mut spawn)
+            .into_iter()
+            .next()
+            .unwrap();
+
+        object_stream.renumber(|old| old);
     }
 }


### PR DESCRIPTION
Please note that this PR was fully AI-generated and is not intended to be merged like this. For a mergeable version, we obviously want more tests + a cleaner API interface + actually cross-checking the impl against the PDF reference. Not asking for a code review here, I just want to have _something_ to get the conversation going a bit and discuss the different trade-offs before committing to a direction.

# Goal
Overall, our goal is  to be able to leverage object streams in krilla. This is important because, especially for tagged PDFs, PDF sizes end up ballooning unnecessary due to the large number of tag nodes usually contained in a PDF. 

# The hard part
Getting _a_ working version is not that hard from a few vibe-coded experiments; in my opinion, the hard part is finding a good trade-off between two different requirements: 

1) Ensuring the implementation is performant (making use of multi-threading when creating and compressing the object streams), at the same time making sure that we don't unnecessarily waste memory (by allocating and copying memory by  repeatedly using APIs like `renumber`).

2) Deciding the right split between what should live in pdf-writer and what can instead be moved to krilla. In addition, the new API should ideally remain as compatible as possible with existing pdf-writer APIs. However, as I will show below, I'm afraid we will have to make some compromises here.

# Current state
Let me start by outlining the current state in krilla. Overall, thanks due to a few refactors I performed, we already are in a much better position to implement object streams than we were 1-2 months ago. 

Right now, we still have this single global [`ChunkContainer` struct](https://github.com/LaurenzV/krilla/blob/7f674464302930db09acd73b7abb5be6eab1eb32/crates/krilla/src/chunk_container.rs#L17-L22) which basically collects everything we write during the serialization process grouped by a "super category" and then a  "sub category". In the end, these categories are then basically copied one after another into the final PDF.

The super category split that I recently introduced is between non-stream chunks, mixed chunks and stream chunks. This means that in the final PDF, all non-stream objects will be grouped together, followed by mixed chunks (which are just from embedded PDFs) and finally all streams. This change already puts us in a very good position to implement object streams, because we conceptually already group everything that can be put in a object stream together (object streams can contain any objects except for other stream objects, which are prohibited).

Then, the sub category for each group basically consists of different "topics". For example, we put all objects that were generated from serializing [color spaces into a different bucket than the ones from external graphics state](https://github.com/LaurenzV/krilla/blob/7f674464302930db09acd73b7abb5be6eab1eb32/crates/krilla/src/chunk_container.rs#L48-L50). This is different to what existed two months ago, where each category actually had a `Vec<Chunk>`, and each object landed in a new chunk. However, this turned out to be a huge waste of memory, hence why it was changed that each category is just represented by a single `Chunk`, which is the better thing to do anyway in my opinion.

Note there is no reason why we would have to group color space objects separately from annotations, it is purely for aesthetic reasons to make the final PDF more organized. In theory, we could just lump pretty much all non-stream objects into a single chunk. However, it's a nice property and I don't see this as a hindrance to implementing object streams. **Therefore, I suggest we keep this grouping for now.**

Once all chunks of each group have been created, we get to the final serialization step which actually concatenates them into a single PDF. This basically happens in two steps:

1) First, [we do a single pass over all chunks to determine a new numbering of objects](https://github.com/LaurenzV/krilla/blob/7f674464302930db09acd73b7abb5be6eab1eb32/crates/krilla/src/chunk_container.rs#L114-L120). There once again is no inherent reason why we have to do this, it just has the nice property that in the final PDFs, object numbers will be in ascending order.

2) Then, using the new number mapping we determined, we more or less just [concatenate all chunks into a single PDF](https://github.com/LaurenzV/krilla/blob/7f674464302930db09acd73b7abb5be6eab1eb32/crates/krilla/src/chunk_container.rs#L140-L142).

That's basically it.

# Removing the renumbering step
Before talking more about object streams, **my first proposal is to remove the renumbering step from the krilla pipeline (i.e. step 1))** (except for embedded PDFs via hayro-write, because those always start with Ref 1). The two reasons for this are 1) It's an unnecessary waste of time because we have to iterate over each object ref to create the mapping. I doubt it's very costly, but still, if it can be avoided why not! But most importantly, 2) I'm really doubtful about being able to support the `renumber_into` API with chunks that contain an object stream. The problem is that object streams themselves are just stream objects, with the special property that they contain PDF-relevant data. In particular, the streams themselves couple the object numbers with the object themselves. This means that if you have a flate-encoded object stream, there is no way of just renumbering its entries into a new chunk without decoding, renumbering and then encoding again. Therefore, I believe we will have to restrict the `renumber_into` API to not allow having any object streams inside of it, and panic in case it does. However, for the `chunk.extend` function this is fine, because we can just merge the xref entries as usual.

Therefore, as a first step I would suggest moving krilla way from making use of that API (except for `hayro-write` PDFs which are stored separately as mixed chunks) so that we don't face this problem further down the road. Yes my OCD also doesn't like the fact that numbers aren't consecutive anymore, but I think it's better to be practical here. 😄 Here is the change, and it's not too bad: https://github.com/LaurenzV/krilla/commit/68f7d38f856cf5ec69b789f3ce411f31995a714e

# Object stream API

With the above thing resolved, let's now get to the real meat, how to implement object streams. Fundamentally, we need some API that 1) iterates over the objects in a chunk and segments them into groups of X (e.g. 100) objects (which is necessary because you are not supposed to put too many object into a single object stream) and 2) does the actual creation of the object stream. 2) Obviously needs to live in pdf-writer, the question is where 1) should live. If 1) lives in krilla, then we would need to basically have to make the `indirect_objects` iterator public, which is kind of ugly because exposing the raw `body` like that doesn't feel right. 

Therefore, I think it's better if the chunking API lives in pdf-writer instead. However, this does have the disadvantage that it makes the API pretty ugly. The reason is that in krilla, we have the specific requirement that we want to be able to handle compressing multiple stream objects at the same time using multi-threading for performance reason. Because of that, in `pdf-writer` the chunking API needs to be very generic to allow implementing this kind of behavior. So this is kind of what I ended up with now. `pdf-writer` exposes this kind of API to split a `Chunk` into a range of compressed stream objects. krilla then basically consumes this API to [create object streams if requested](https://github.com/LaurenzV/krilla/commit/8e46b951e0863f6191057b447bf8b9e2ac171d98). Similarly to before, that was completely PR-generated so please don't interpret this as me wanting to be the final version; I think the code can be made to be less verbose. But before I put more time into this, I would like to get the high-level direction settled first.

Curious to hear your thoughts!